### PR TITLE
[#4] Feat : Post CRUD 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -13,14 +13,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostResponse;
+import com.clover.habbittracker.domain.post.entity.Category;
 import com.clover.habbittracker.domain.post.service.PostService;
-import com.clover.habbittracker.global.dto.BaseResponse;
-import com.clover.habbittracker.global.dto.ResponseType;
+import com.clover.habbittracker.global.dto.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,31 +33,32 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping
-	public ResponseEntity<BaseResponse<Void>> createPost(@AuthenticationPrincipal Long memberId, @RequestBody PostRequest request) {
+	public ResponseEntity<ApiResponse<Void>> createPost(@AuthenticationPrincipal Long memberId,
+		@RequestBody PostRequest request) {
 		Long postId = postService.register(memberId, request);
-		BaseResponse<Void> response = BaseResponse.of(null, ResponseType.POST_CREATE);
-		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(response);
+		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(ApiResponse.success());
 	}
+
 	@GetMapping
-	public ResponseEntity<BaseResponse<List<PostResponse>>> getPostList(@PageableDefault(size = 15) Pageable pageable) {
-		List<PostResponse> postList = postService.getPostList(pageable);
-		BaseResponse<List<PostResponse>> response = BaseResponse.of(postList, ResponseType.POST_READ);
-		return ResponseEntity.ok().body(response);
+	public ResponseEntity<ApiResponse<List<PostResponse>>> getPostList(
+		@PageableDefault(size = 15) Pageable pageable,
+		@RequestParam(required = false) Category category
+	) {
+		List<PostResponse> postList = postService.getPostList(pageable, category);
+		return ResponseEntity.ok().body(ApiResponse.success(postList));
 	}
 
 	@GetMapping("/{postId}")
-	public ResponseEntity<BaseResponse<PostDetailResponse>> getPost(@PathVariable Long postId){
+	public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long postId) {
 		PostDetailResponse postDetail = postService.getPost(postId);
-		BaseResponse<PostDetailResponse> response = BaseResponse.of(postDetail, ResponseType.POST_READ);
-		return ResponseEntity.ok().body(response);
+		return ResponseEntity.ok().body(ApiResponse.success(postDetail));
 	}
 
-
 	@PutMapping("/{postId}")
-	public ResponseEntity<BaseResponse<PostResponse>> updatePost(@PathVariable Long postId, @RequestBody PostRequest request) {
+	public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long postId,
+		@RequestBody PostRequest request) {
 		PostResponse postResponse = postService.updatePost(postId, request);
-		BaseResponse<PostResponse> response = BaseResponse.of(postResponse, ResponseType.POST_UPDATE);
-		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(response);
+		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(ApiResponse.success(postResponse));
 	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -5,8 +5,10 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,10 +57,18 @@ public class PostController {
 	}
 
 	@PutMapping("/{postId}")
-	public ResponseEntity<ApiResponse<PostResponse>> updatePost(@PathVariable Long postId,
+	public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+		@PathVariable Long postId,
+		@AuthenticationPrincipal Long memberId,
 		@RequestBody PostRequest request) {
-		PostResponse postResponse = postService.updatePost(postId, request);
+		PostResponse postResponse = postService.updatePost(postId, request, memberId);
 		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(ApiResponse.success(postResponse));
+	}
+
+	@DeleteMapping("/{postId}")
+	public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long postId, @AuthenticationPrincipal Long memberId) {
+		postService.deletePost(postId, memberId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success());
 	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,9 +32,10 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping
-	public ResponseEntity<BaseResponse<Void>> createPost(@AuthenticationPrincipal Long memberId, PostRequest request) {
+	public ResponseEntity<BaseResponse<Void>> createPost(@AuthenticationPrincipal Long memberId, @RequestBody PostRequest request) {
 		Long postId = postService.register(memberId, request);
-		return ResponseEntity.created(URI.create("/posts" + postId.toString())).body(BaseResponse.of(null,ResponseType.POST_READ));
+		BaseResponse<Void> response = BaseResponse.of(null, ResponseType.POST_CREATE);
+		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(response);
 	}
 	@GetMapping
 	public ResponseEntity<BaseResponse<List<PostResponse>>> getPostList(@PageableDefault(size = 15) Pageable pageable) {
@@ -51,9 +53,10 @@ public class PostController {
 
 
 	@PutMapping("/{postId}")
-	public void updatePost(@PathVariable Long postId, PostRequest request) {
-		postService.updatePost(postId,request);
-
+	public ResponseEntity<BaseResponse<PostResponse>> updatePost(@PathVariable Long postId, @RequestBody PostRequest request) {
+		PostResponse postResponse = postService.updatePost(postId, request);
+		BaseResponse<PostResponse> response = BaseResponse.of(postResponse, ResponseType.POST_UPDATE);
+		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(response);
 	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -1,9 +1,25 @@
 package com.clover.habbittracker.domain.post.api;
 
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
+import com.clover.habbittracker.domain.post.dto.PostResponse;
 import com.clover.habbittracker.domain.post.service.PostService;
+import com.clover.habbittracker.global.dto.BaseResponse;
+import com.clover.habbittracker.global.dto.ResponseType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,5 +29,31 @@ import lombok.RequiredArgsConstructor;
 public class PostController {
 
 	private final PostService postService;
+
+	@PostMapping
+	public ResponseEntity<BaseResponse<Void>> createPost(@AuthenticationPrincipal Long memberId, PostRequest request) {
+		Long postId = postService.register(memberId, request);
+		return ResponseEntity.created(URI.create("/posts" + postId.toString())).body(BaseResponse.of(null,ResponseType.POST_READ));
+	}
+	@GetMapping
+	public ResponseEntity<BaseResponse<List<PostResponse>>> getPostList(@PageableDefault(size = 15) Pageable pageable) {
+		List<PostResponse> postList = postService.getPostList(pageable);
+		BaseResponse<List<PostResponse>> response = BaseResponse.of(postList, ResponseType.POST_READ);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/{postId}")
+	public ResponseEntity<BaseResponse<PostDetailResponse>> getPost(@PathVariable Long postId){
+		PostDetailResponse postDetail = postService.getPost(postId);
+		BaseResponse<PostDetailResponse> response = BaseResponse.of(postDetail, ResponseType.POST_READ);
+		return ResponseEntity.ok().body(response);
+	}
+
+
+	@PutMapping("/{postId}")
+	public void updatePost(@PathVariable Long postId, PostRequest request) {
+		postService.updatePost(postId,request);
+
+	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
@@ -2,6 +2,7 @@ package com.clover.habbittracker.domain.post.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import com.clover.habbittracker.domain.comment.entity.Comment;
 import com.clover.habbittracker.domain.like.entity.Like;
@@ -17,8 +18,9 @@ public class PostDetailResponse {
 	private String title;
 	private String content;
 	private Category category;
+	private Long views;
 	private List<Comment> comments;
-	private List<Like> likes;
+	private Set<Like> likes;
 	private LocalDateTime createDate;
 	private LocalDateTime updateDate;
 
@@ -27,6 +29,7 @@ public class PostDetailResponse {
 			.title(post.getTitle())
 			.content(post.getContent())
 			.category(post.getCategory())
+			.views(post.getViews())
 			.comments(post.getComments())
 			.likes(post.getLikes())
 			.createDate(post.getCreatedAt())

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
@@ -1,0 +1,36 @@
+package com.clover.habbittracker.domain.post.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.like.entity.Like;
+import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.entity.Post;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostDetailResponse {
+	private String title;
+	private String content;
+	private Category category;
+	private List<Comment> comments;
+	private List<Like> likes;
+	private LocalDateTime createDate;
+	private LocalDateTime updateDate;
+
+	public static PostDetailResponse from(Post post) {
+		return PostDetailResponse.builder()
+			.title(post.getTitle())
+			.content(post.getContent())
+			.category(post.getCategory())
+			.comments(post.getComments())
+			.likes(post.getLikes())
+			.createDate(post.getCreatedAt())
+			.updateDate(post.getUpdatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
@@ -2,7 +2,6 @@ package com.clover.habbittracker.domain.post.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 
 import com.clover.habbittracker.domain.comment.entity.Comment;
 import com.clover.habbittracker.domain.like.entity.Like;
@@ -20,7 +19,7 @@ public class PostDetailResponse {
 	private Category category;
 	private Long views;
 	private List<Comment> comments;
-	private Set<Like> likes;
+	private List<Like> likes;
 	private LocalDateTime createDate;
 	private LocalDateTime updateDate;
 

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
@@ -1,0 +1,12 @@
+package com.clover.habbittracker.domain.post.dto;
+
+import com.clover.habbittracker.domain.post.entity.Category;
+
+import lombok.Getter;
+
+@Getter
+public class PostRequest {
+	String title;
+	String content;
+	Category category;
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class PostResponse {
+	private Long id;
 	private String title;
 	private String content;
 	private Category category;
@@ -21,6 +22,7 @@ public class PostResponse {
 
 	public static PostResponse from(Post post) {
 		return PostResponse.builder()
+			.id(post.getId())
 			.title(post.getTitle())
 			.content(post.getContent())
 			.category(post.getCategory())

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
@@ -1,0 +1,33 @@
+package com.clover.habbittracker.domain.post.dto;
+
+import java.time.LocalDateTime;
+
+import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.entity.Post;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PostResponse {
+	private String title;
+	private String content;
+	private Category category;
+	private Long views;
+	private Integer numOfComment;
+	private Integer numOfLikes;
+	private LocalDateTime createDate;
+
+	public static PostResponse from(Post post) {
+		return PostResponse.builder()
+			.title(post.getTitle())
+			.content(post.getContent())
+			.category(post.getCategory())
+			.views(post.getViews())
+			.numOfComment(post.getComments().size())
+			.numOfLikes(post.getLikes().size())
+			.createDate(post.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -3,10 +3,9 @@ package com.clover.habbittracker.domain.post.entity;
 import static lombok.AccessLevel.*;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -59,6 +58,7 @@ public class Post extends BaseEntity {
 		cascade = CascadeType.REMOVE,
 		orphanRemoval = true,
 		fetch = FetchType.LAZY)
+	@BatchSize(size = 50)
 	private final List<Comment> comments = new ArrayList<>();
 
 	@OneToMany(
@@ -66,7 +66,8 @@ public class Post extends BaseEntity {
 		cascade = CascadeType.REMOVE,
 		orphanRemoval = true,
 		fetch = FetchType.LAZY)
-	private final Set<Like> likes = new HashSet<>();
+	@BatchSize(size = 50)
+	private final List<Like> likes = new ArrayList<>();
 
 	@Builder
 	public Post(String title, String content, Category category, Member member) {

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -10,8 +10,9 @@ import org.hibernate.annotations.Where;
 
 import com.clover.habbittracker.domain.comment.entity.Comment;
 import com.clover.habbittracker.domain.like.entity.Like;
-import com.clover.habbittracker.domain.like.entity.Type;
 import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
+import com.clover.habbittracker.global.entity.BaseEntity;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -33,7 +34,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @Where(clause = "deleted = false")
 @SQLDelete(sql = "UPDATE post set deleted = true where id=?")
-public class Post {
+public class Post extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -71,5 +72,11 @@ public class Post {
 		this.content = content;
 		this.category = category;
 		this.member = member;
+	}
+
+	public void updatePost(PostRequest postRequest) {
+		this.title = postRequest.getTitle();
+		this.content = postRequest.getContent();
+		this.category = postRequest.getCategory();
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -3,7 +3,9 @@ package com.clover.habbittracker.domain.post.entity;
 import static lombok.AccessLevel.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -64,7 +66,7 @@ public class Post extends BaseEntity {
 		cascade = CascadeType.REMOVE,
 		orphanRemoval = true,
 		fetch = FetchType.LAZY)
-	private final List<Like> likes = new ArrayList<>();
+	private final Set<Like> likes = new HashSet<>();
 
 	@Builder
 	public Post(String title, String content, Category category, Member member) {
@@ -72,6 +74,7 @@ public class Post extends BaseEntity {
 		this.content = content;
 		this.category = category;
 		this.member = member;
+		this.views = 0L;
 	}
 
 	public void updatePost(PostRequest postRequest) {

--- a/src/main/java/com/clover/habbittracker/domain/post/exception/PostNotFoundException.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/exception/PostNotFoundException.java
@@ -1,0 +1,11 @@
+package com.clover.habbittracker.domain.post.exception;
+
+import com.clover.habbittracker.global.exception.BaseException;
+import com.clover.habbittracker.global.exception.ErrorType;
+
+public class PostNotFoundException extends BaseException {
+
+	public PostNotFoundException(Long postId) {
+		super(postId, ErrorType.POST_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
@@ -1,0 +1,18 @@
+package com.clover.habbittracker.domain.post.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
+
+import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.entity.Post;
+
+public interface PostCustomRepository {
+	Page<Post> findAllPostsSummary(Pageable pageable, Category category);
+
+	Optional<Post> joinCommentAndLikeFindById(@Param("postId") Long postId);
+
+	Long updateViews(Long postId);
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.clover.habbittracker.domain.post.repository;
+
+import static com.clover.habbittracker.domain.comment.entity.QComment.*;
+import static com.clover.habbittracker.domain.member.entity.QMember.*;
+import static com.clover.habbittracker.domain.post.entity.QPost.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Page<Post> findAllPostsSummary(Pageable pageable, Category category) {
+
+		List<Post> content = jpaQueryFactory.selectFrom(post)
+			.leftJoin(post.member, member).fetchJoin()
+			.where(eqCategory(category))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(post.createdAt.desc())
+			.fetch();
+
+		Long count = getCount();
+
+		return new PageImpl<>(content, pageable, count);
+	}
+
+	@Override
+	public Optional<Post> joinCommentAndLikeFindById(Long postId) {
+		Post result = jpaQueryFactory.selectFrom(post)
+			.leftJoin(post.member, member)
+			.fetchJoin()
+			.leftJoin(post.comments, comment)
+			.fetchJoin()
+			.where(eqId(postId))
+			.fetchOne();
+		return Optional.ofNullable(result);
+	}
+
+	@Override
+	public Long updateViews(Long postId) {
+		return jpaQueryFactory.update(post)
+			.set(post.views, post.views.add(1))
+			.where(eqId(postId))
+			.execute();
+	}
+
+	private BooleanExpression eqId(Long postId) {
+		if (postId != null) {
+			return post.id.eq(postId);
+		}
+		return null;
+	}
+
+	private BooleanExpression eqCategory(Category category) {
+		if (category != null) {
+			return post.category.eq(category);
+		}
+		return null;
+	}
+
+	private Long getCount() {
+		return jpaQueryFactory.select(post.count())
+			.from(post)
+			.fetchOne();
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostRepository.java
@@ -1,8 +1,16 @@
 package com.clover.habbittracker.domain.post.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.clover.habbittracker.domain.post.entity.Post;
 
-public interface PostRepository extends JpaRepository<Post,Long> {
+public interface PostRepository extends JpaRepository<Post, Long> {
+	@Query("""
+			SELECT p.title, p.content, p.category, p.views, p.createdAt, p.likes, p.comments
+			FROM Post p
+		""")
+	Page<Post> findAllPostsSummary(Pageable pageable);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostRepository.java
@@ -1,37 +1,8 @@
 package com.clover.habbittracker.domain.post.repository;
 
-import java.util.Optional;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.clover.habbittracker.domain.post.entity.Post;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
-	@Query(value = """
-			SELECT p
-			FROM Post p
-			LEFT JOIN FETCH p.comments pc
-			LEFT JOIN FETCH p.likes pl
-		""",
-		countQuery = "SELECT count(p) FROM Post p")
-	Page<Post> findAllPostsSummary(Pageable pageable);  //TODO: pagination 과 Fetch join 을 같이 사용하면 안됨.
-
-	@Query("""
-	SELECT p
-	FROM Post p
-	LEFT JOIN FETCH p.comments pc
-	LEFT JOIN FETCH p.likes pl
-	WHERE p.id = :postId
-""")
-	Optional<Post> joinCommentAndLikeFindById(@Param("postId") Long postId);
-
-	@Modifying
-	@Query("UPDATE Post p SET p.views = p.views + 1 WHERE p.id = :postId")
-	int updateViews(Long postId);
-
+public interface PostRepository extends PostCustomRepository, JpaRepository<Post, Long> {
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostRepository.java
@@ -1,16 +1,37 @@
 package com.clover.habbittracker.domain.post.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.clover.habbittracker.domain.post.entity.Post;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-	@Query("""
-			SELECT p.title, p.content, p.category, p.views, p.createdAt, p.likes, p.comments
+	@Query(value = """
+			SELECT p
 			FROM Post p
-		""")
-	Page<Post> findAllPostsSummary(Pageable pageable);
+			LEFT JOIN FETCH p.comments pc
+			LEFT JOIN FETCH p.likes pl
+		""",
+		countQuery = "SELECT count(p) FROM Post p")
+	Page<Post> findAllPostsSummary(Pageable pageable);  //TODO: pagination 과 Fetch join 을 같이 사용하면 안됨.
+
+	@Query("""
+	SELECT p
+	FROM Post p
+	LEFT JOIN FETCH p.comments pc
+	LEFT JOIN FETCH p.likes pl
+	WHERE p.id = :postId
+""")
+	Optional<Post> joinCommentAndLikeFindById(@Param("postId") Long postId);
+
+	@Modifying
+	@Query("UPDATE Post p SET p.views = p.views + 1 WHERE p.id = :postId")
+	int updateViews(Long postId);
+
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
@@ -15,5 +15,5 @@ public interface PostService {
 
 	List<PostResponse> getPostList(Pageable pageable);
 
-	void updatePost(Long postId, PostRequest request);
+	PostResponse updatePost(Long postId, PostRequest request);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
@@ -16,5 +16,7 @@ public interface PostService {
 
 	List<PostResponse> getPostList(Pageable pageable, Category category);
 
-	PostResponse updatePost(Long postId, PostRequest request);
+	PostResponse updatePost(Long postId, PostRequest request, Long memberId);
+
+	void deletePost(Long postId, Long memberId);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
@@ -1,16 +1,19 @@
 package com.clover.habbittracker.domain.post.service;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
 
-import com.clover.habbittracker.domain.post.repository.PostRepository;
+import org.springframework.data.domain.Pageable;
 
-import lombok.RequiredArgsConstructor;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
+import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostResponse;
 
-@Service
-@RequiredArgsConstructor
-public class PostService {
+public interface PostService {
+	Long register(Long memberId, PostRequest request);
 
-	private final PostRepository postRepository;
+	PostDetailResponse getPost(Long postId);
 
+	List<PostResponse> getPostList(Pageable pageable);
 
+	void updatePost(Long postId, PostRequest request);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
@@ -7,13 +7,14 @@ import org.springframework.data.domain.Pageable;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
 import com.clover.habbittracker.domain.post.dto.PostResponse;
+import com.clover.habbittracker.domain.post.entity.Category;
 
 public interface PostService {
 	Long register(Long memberId, PostRequest request);
 
 	PostDetailResponse getPost(Long postId);
 
-	List<PostResponse> getPostList(Pageable pageable);
+	List<PostResponse> getPostList(Pageable pageable, Category category);
 
 	PostResponse updatePost(Long postId, PostRequest request);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -14,6 +14,7 @@ import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
 import com.clover.habbittracker.domain.post.dto.PostResponse;
+import com.clover.habbittracker.domain.post.entity.Category;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.repository.PostRepository;
 
@@ -43,15 +44,16 @@ public class PostServiceImpl implements PostService {
 	@Override
 	@Transactional
 	public PostDetailResponse getPost(Long postId) {
-		Post post = postRepository.joinCommentAndLikeFindById(postId).orElseThrow(NoSuchElementException::new); //TODO : 임시 예외 처리
+		Post post = postRepository.joinCommentAndLikeFindById(postId)
+			.orElseThrow(NoSuchElementException::new); //TODO : 임시 예외 처리
 		postRepository.updateViews(postId);
 		return PostDetailResponse.from(post);
 
 	}
 
 	@Override
-	public List<PostResponse> getPostList(Pageable pageable) {
-		Page<Post> postsSummary = postRepository.findAllPostsSummary(pageable);
+	public List<PostResponse> getPostList(Pageable pageable, Category category) {
+		Page<Post> postsSummary = postRepository.findAllPostsSummary(pageable, category);
 		return postsSummary.stream().map(PostResponse::from).toList();
 	}
 

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -1,7 +1,6 @@
 package com.clover.habbittracker.domain.post.service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,12 +10,14 @@ import org.springframework.transaction.annotation.Transactional;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.exception.MemberNotFoundException;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
-import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostResponse;
 import com.clover.habbittracker.domain.post.entity.Category;
 import com.clover.habbittracker.domain.post.entity.Post;
+import com.clover.habbittracker.domain.post.exception.PostNotFoundException;
 import com.clover.habbittracker.domain.post.repository.PostRepository;
+import com.clover.habbittracker.global.exception.PermissionDeniedException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,8 +46,8 @@ public class PostServiceImpl implements PostService {
 	@Transactional
 	public PostDetailResponse getPost(Long postId) {
 		Post post = postRepository.joinCommentAndLikeFindById(postId)
-			.orElseThrow(NoSuchElementException::new); //TODO : 임시 예외 처리
-		postRepository.updateViews(postId);
+			.orElseThrow(() -> new PostNotFoundException(postId));
+		postRepository.updateViews(post.getId());
 		return PostDetailResponse.from(post);
 
 	}
@@ -59,9 +60,24 @@ public class PostServiceImpl implements PostService {
 
 	@Override
 	@Transactional
-	public PostResponse updatePost(Long postId, PostRequest request) {
-		Post post = postRepository.findById(postId).orElseThrow(NoSuchElementException::new);//TODO : 임시 예외 처리
+	public PostResponse updatePost(Long postId, PostRequest request, Long memberId) {
+		Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(postId));
+		verifyPermissions(post.getMember(), memberId);
 		post.updatePost(request);
 		return PostResponse.from(post);
+	}
+
+	@Override
+	@Transactional
+	public void deletePost(Long postId, Long memberId) {
+		Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(postId));
+		verifyPermissions(post.getMember(), memberId);
+		postRepository.deleteById(postId);
+	}
+
+	private void verifyPermissions(Member member, Long memberId) {
+		if (!member.getId().equals(memberId)) {
+			throw new PermissionDeniedException(memberId);
+		}
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -41,9 +41,11 @@ public class PostServiceImpl implements PostService {
 	}
 
 	@Override
+	@Transactional
 	public PostDetailResponse getPost(Long postId) {
-		return PostDetailResponse.from(
-			postRepository.findById(postId).orElseThrow(NoSuchElementException::new)); //TODO : 임시 예외 처리
+		Post post = postRepository.joinCommentAndLikeFindById(postId).orElseThrow(NoSuchElementException::new); //TODO : 임시 예외 처리
+		postRepository.updateViews(postId);
+		return PostDetailResponse.from(post);
 
 	}
 
@@ -55,8 +57,9 @@ public class PostServiceImpl implements PostService {
 
 	@Override
 	@Transactional
-	public void updatePost(Long postId, PostRequest request) {
+	public PostResponse updatePost(Long postId, PostRequest request) {
 		Post post = postRepository.findById(postId).orElseThrow(NoSuchElementException::new);//TODO : 임시 예외 처리
 		post.updatePost(request);
+		return PostResponse.from(post);
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -1,0 +1,62 @@
+package com.clover.habbittracker.domain.post.service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.exception.MemberNotFoundException;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
+import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostResponse;
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.clover.habbittracker.domain.post.repository.PostRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostServiceImpl implements PostService {
+
+	private final PostRepository postRepository;
+
+	private final MemberRepository memberRepository;
+
+	public Long register(Long memberId, PostRequest request) {
+		Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+		Post post = Post.builder()
+			.title(request.getTitle())
+			.content(request.getContent())
+			.category(request.getCategory())
+			.member(member)
+			.build();
+		postRepository.save(post);
+
+		return post.getId();
+	}
+
+	@Override
+	public PostDetailResponse getPost(Long postId) {
+		return PostDetailResponse.from(
+			postRepository.findById(postId).orElseThrow(NoSuchElementException::new)); //TODO : 임시 예외 처리
+
+	}
+
+	@Override
+	public List<PostResponse> getPostList(Pageable pageable) {
+		Page<Post> postsSummary = postRepository.findAllPostsSummary(pageable);
+		return postsSummary.stream().map(PostResponse::from).toList();
+	}
+
+	@Override
+	@Transactional
+	public void updatePost(Long postId, PostRequest request) {
+		Post post = postRepository.findById(postId).orElseThrow(NoSuchElementException::new);//TODO : 임시 예외 처리
+		post.updatePost(request);
+	}
+}

--- a/src/main/java/com/clover/habbittracker/global/dto/ApiResponse.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/ApiResponse.java
@@ -1,0 +1,49 @@
+package com.clover.habbittracker.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ApiResponse<T> {
+	private final String code;
+	private final String message;
+	private final T data;
+
+	@Builder
+	private ApiResponse(ResultCode code, String message, T data) {
+		this.code = code.name();
+		this.message = message;
+		this.data = data;
+	}
+
+
+	public static <T> ApiResponse<T> success() {
+		return ApiResponse.<T>builder()
+			.code(ResultCode.SUCCESS)
+			.message(ResultCode.SUCCESS.getMessage())
+			.build();
+	}
+
+	public static <T> ApiResponse<T> success(T data) {
+		return ApiResponse.<T>builder()
+			.code(ResultCode.SUCCESS)
+			.message(ResultCode.SUCCESS.getMessage())
+			.data(data)
+			.build();
+	}
+
+	public static <T> ApiResponse<T> failure(ResultCode code) {
+		return ApiResponse.<T>builder()
+			.code(code)
+			.message(code.getMessage())
+			.build();
+	}
+
+}

--- a/src/main/java/com/clover/habbittracker/global/dto/BaseResponse.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/BaseResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Deprecated
 public class BaseResponse<T> {
 
 	private final String code;

--- a/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
@@ -3,6 +3,7 @@ package com.clover.habbittracker.global.dto;
 import lombok.Getter;
 
 @Getter
+@Deprecated
 public enum ResponseType {
 	HABIT_CREATE("습관이 정상적으로 생성 되었습니다."),
 	HABIT_READ("습관 조회 요청이 성공 하였습니다."),

--- a/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
@@ -16,7 +16,9 @@ public enum ResponseType {
 	DIARY_CREATE("회고록이 정상적으로 생성 되었습니다."),
 	DIARY_READ("회고록 조회 요청이 성공하였습니다."),
 	DIARY_UPDATE("회고록 정보가 정상적으로 업데이트 되었습니다."),
-	DIARY_DELETE("회고록이 정상적으로 삭제 되었습니다.");
+	DIARY_DELETE("회고록이 정상적으로 삭제 되었습니다."),
+	POST_READ("글 조회 요청이 성공하였습니다.");
+
 
 	private final String message;
 

--- a/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/ResponseType.java
@@ -17,7 +17,9 @@ public enum ResponseType {
 	DIARY_READ("회고록 조회 요청이 성공하였습니다."),
 	DIARY_UPDATE("회고록 정보가 정상적으로 업데이트 되었습니다."),
 	DIARY_DELETE("회고록이 정상적으로 삭제 되었습니다."),
-	POST_READ("글 조회 요청이 성공하였습니다.");
+	POST_READ("글 조회 요청이 성공하였습니다."),
+	POST_CREATE("글이 정상적으로 생성 되었습니다."),
+	POST_UPDATE("글이 정상적으로 업데이트 되었습니다.");
 
 
 	private final String message;

--- a/src/main/java/com/clover/habbittracker/global/dto/ResultCode.java
+++ b/src/main/java/com/clover/habbittracker/global/dto/ResultCode.java
@@ -1,12 +1,13 @@
-package com.clover.habbittracker.global.exception;
+package com.clover.habbittracker.global.dto;
 
 import org.springframework.http.HttpStatus;
 
 import lombok.Getter;
 
 @Getter
-@Deprecated
-public enum ErrorType {
+public enum ResultCode {
+
+	SUCCESS(HttpStatus.OK , "성공"),
 
 	INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, "내용이 없습니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러 입니다."),
@@ -25,10 +26,10 @@ public enum ErrorType {
 	DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "회고록 정보가 존재하지 않습니다.");
 
 	private final HttpStatus status;
-	private final String errorMsg;
+	private final String message;
 
-	ErrorType(HttpStatus status, String errorMsg) {
+	ResultCode(HttpStatus status, String message) {
 		this.status = status;
-		this.errorMsg = errorMsg;
+		this.message = message;
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/exception/ErrorType.java
+++ b/src/main/java/com/clover/habbittracker/global/exception/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
 
 	INVALID_ARGUMENTS(HttpStatus.BAD_REQUEST, "내용이 없습니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러 입니다."),
+	NO_PERMISSIONS(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
 
 	INVALID_JWT_STRUCTURE(HttpStatus.BAD_REQUEST,"잘못된 토큰 구조입니다."),
 	EXPIRED_JWT(HttpStatus.BAD_REQUEST,"유효시간이 만료된 토큰입니다."),
@@ -22,7 +23,10 @@ public enum ErrorType {
 	HABIT_CHECK_EXPIRED(HttpStatus.BAD_REQUEST, "습관체크는 오늘만 가능합니다."),
 
 	DIARY_EXPIRED(HttpStatus.BAD_REQUEST, "회고록은 작성 후 24시간 이내만 수정 할 수 있습니다."),
-	DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "회고록 정보가 존재하지 않습니다.");
+	DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "회고록 정보가 존재하지 않습니다."),
+
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "글 정보를 찾을 수 없습니다.");
+
 
 	private final HttpStatus status;
 	private final String errorMsg;

--- a/src/main/java/com/clover/habbittracker/global/exception/PermissionDeniedException.java
+++ b/src/main/java/com/clover/habbittracker/global/exception/PermissionDeniedException.java
@@ -1,0 +1,7 @@
+package com.clover.habbittracker.global.exception;
+
+public class PermissionDeniedException extends BaseException {
+	public PermissionDeniedException(Long memberId) {
+		super(memberId,ErrorType.NO_PERMISSIONS);
+	}
+}

--- a/src/main/java/com/clover/habbittracker/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/security/config/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
 			.requestMatchers("/diaries").authenticated()
 			.requestMatchers("/habits").authenticated()
 			.requestMatchers("/habits/**").authenticated()
+			.requestMatchers("/posts").authenticated()
+			.requestMatchers("/posts/**").authenticated()
 			.anyRequest().permitAll()
 			.and()
 			.oauth2Login()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        globally_quoted_identifiers: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
   config:
     import: application-token.yml, application-security.yml


### PR DESCRIPTION
## 작업 사항

**Post CRUD 를 추가하였습니다.**

- Post 는 회원만 가능하도록 설정하였습니다.
- 해당 Post 를 작성 한 사람만 수정,삭제 할 수 있습니다.
- 기존 delete 와 다르게 soft delete 처리로 변경하였습니다.
- OneToMany 관계에서 fetchJoin 을 활용하여 N + 1 을 해결 하려 했지만, OneToMany fetchJoin 은 하나의 join 만 허용 하므로 fetchJoin 이 아닌 BatchSize를 설정하였습니다
- Post 조회 시 페이지네이션을 적용하였습니다. 기본은 15개씩 조회 됩니다.
- 동적 쿼리를 활용하여 Category 별 조회도 가능합니다.

## 특이사항

- 조회수를 업데이트 하기 위해 update 쿼리를 하나 추가로 더 날립니다! 이유는 동시성 문제로 조회수가 정상적으로 올라가지 않는걸 방지하기 위해 update 쿼리를 하나 더 사용하도록 했어요~!
- like 엔티티에 경우 MySql 예약어 문제가 있어서 설정파일에 임시로 설정 추가하였습니다~~ Emoji 로 변경되면 설정 제거하도록 할게요!
- QueryDSL 을 처음 사용하다보니 좀 미숙한 부분이 있을 수 있습니다! 확인 부탁드려요!!
- 테스트 코드도 추가 할 예정입니다!