### PR TITLE
[#4] Fix : Post API 코드 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
     implementation 'com.mysql:mysql-connector-j:8.0.32'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
-    compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -43,6 +43,11 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    //mapstruct  * Lombok 의 getter, setter, builder 를 이용하여 생성되므로 Lombok 먼저 의존성 주입 후 사용해야함.
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
+    // spring restdocs
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }

--- a/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,14 @@
+package com.clover.habbittracker.domain.comment.dto;
+
+import java.util.List;
+
+import com.clover.habbittracker.domain.comment.entity.Comment;
+
+public record CommentResponse(
+	Long id,
+	String content
+) {
+	public static List<CommentResponse> from(List<Comment> comments) {
+		return comments.stream().map(comment -> new CommentResponse(comment.getId(), comment.getContent())).toList();
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -1,11 +1,12 @@
 package com.clover.habbittracker.domain.post.api;
 
+import static org.springframework.http.HttpStatus.*;
+
 import java.net.URI;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
@@ -35,10 +37,14 @@ public class PostController {
 	private final PostService postService;
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> createPost(@AuthenticationPrincipal Long memberId,
-		@RequestBody PostRequest request) {
+	public ResponseEntity<ApiResponse<Void>> createPost(
+		@AuthenticationPrincipal Long memberId,
+		@RequestBody PostRequest request
+	) {
 		Long postId = postService.register(memberId, request);
-		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(ApiResponse.success());
+		URI location = URI.create("/posts/" + postId.toString());
+		ApiResponse<Void> response = ApiResponse.success();
+		return ResponseEntity.created(location).body(response);
 	}
 
 	@GetMapping
@@ -47,28 +53,39 @@ public class PostController {
 		@RequestParam(required = false) Category category
 	) {
 		List<PostResponse> postList = postService.getPostList(pageable, category);
-		return ResponseEntity.ok().body(ApiResponse.success(postList));
+		ApiResponse<List<PostResponse>> response = ApiResponse.success(postList);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@GetMapping("/{postId}")
-	public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(@PathVariable Long postId) {
+	public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(
+		@PathVariable Long postId
+	) {
 		PostDetailResponse postDetail = postService.getPost(postId);
-		return ResponseEntity.ok().body(ApiResponse.success(postDetail));
+		ApiResponse<PostDetailResponse> response = ApiResponse.success(postDetail);
+		return ResponseEntity.ok().body(response);
 	}
 
 	@PutMapping("/{postId}")
 	public ResponseEntity<ApiResponse<PostResponse>> updatePost(
 		@PathVariable Long postId,
 		@AuthenticationPrincipal Long memberId,
-		@RequestBody PostRequest request) {
+		@RequestBody PostRequest request
+	) {
 		PostResponse postResponse = postService.updatePost(postId, request, memberId);
-		return ResponseEntity.created(URI.create("/posts/" + postId.toString())).body(ApiResponse.success(postResponse));
+		ApiResponse<PostResponse> response = ApiResponse.success(postResponse);
+		URI location = URI.create("/posts/" + postId.toString());
+		return ResponseEntity.ok().location(location).body(response);
 	}
 
 	@DeleteMapping("/{postId}")
-	public ResponseEntity<ApiResponse<Void>> deletePost(@PathVariable Long postId, @AuthenticationPrincipal Long memberId) {
+	@ResponseStatus(NO_CONTENT)
+	public ApiResponse<Void> deletePost(
+		@PathVariable Long postId,
+		@AuthenticationPrincipal Long memberId
+	) {
 		postService.deletePost(postId, memberId);
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success());
+		return ApiResponse.success();
 	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
@@ -3,36 +3,19 @@ package com.clover.habbittracker.domain.post.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.comment.dto.CommentResponse;
 import com.clover.habbittracker.domain.like.entity.Like;
 import com.clover.habbittracker.domain.post.entity.Category;
-import com.clover.habbittracker.domain.post.entity.Post;
 
-import lombok.Builder;
-import lombok.Getter;
+public record PostDetailResponse(
+	String title,
+	String content,
+	Category category,
+	Long views,
+	List<CommentResponse> comments,
+	List<Like> likes,
+	LocalDateTime createDate,
+	LocalDateTime updateDate
+) {
 
-@Getter
-@Builder
-public class PostDetailResponse {
-	private String title;
-	private String content;
-	private Category category;
-	private Long views;
-	private List<Comment> comments;
-	private List<Like> likes;
-	private LocalDateTime createDate;
-	private LocalDateTime updateDate;
-
-	public static PostDetailResponse from(Post post) {
-		return PostDetailResponse.builder()
-			.title(post.getTitle())
-			.content(post.getContent())
-			.category(post.getCategory())
-			.views(post.getViews())
-			.comments(post.getComments())
-			.likes(post.getLikes())
-			.createDate(post.getCreatedAt())
-			.updateDate(post.getUpdatedAt())
-			.build();
-	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
@@ -2,11 +2,10 @@ package com.clover.habbittracker.domain.post.dto;
 
 import com.clover.habbittracker.domain.post.entity.Category;
 
-import lombok.Getter;
+public record PostRequest(
+	String title,
+	String content,
+	Category category
+) {
 
-@Getter
-public class PostRequest {
-	private String title;
-	private String content;
-	private Category category;
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class PostRequest {
-	String title;
-	String content;
-	Category category;
+	private String title;
+	private String content;
+	private Category category;
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
@@ -3,33 +3,15 @@ package com.clover.habbittracker.domain.post.dto;
 import java.time.LocalDateTime;
 
 import com.clover.habbittracker.domain.post.entity.Category;
-import com.clover.habbittracker.domain.post.entity.Post;
 
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder
-public class PostResponse {
-	private Long id;
-	private String title;
-	private String content;
-	private Category category;
-	private Long views;
-	private Integer numOfComment;
-	private Integer numOfLikes;
-	private LocalDateTime createDate;
-
-	public static PostResponse from(Post post) {
-		return PostResponse.builder()
-			.id(post.getId())
-			.title(post.getTitle())
-			.content(post.getContent())
-			.category(post.getCategory())
-			.views(post.getViews())
-			.numOfComment(post.getComments().size())
-			.numOfLikes(post.getLikes().size())
-			.createDate(post.getCreatedAt())
-			.build();
-	}
+public record PostResponse(
+	Long id,
+	String title,
+	String content,
+	Category category,
+	Long views,
+	Integer numOfComments,
+	Integer numOfLikes,
+	LocalDateTime createDate
+) {
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -79,8 +79,8 @@ public class Post extends BaseEntity {
 	}
 
 	public void updatePost(PostRequest postRequest) {
-		this.title = postRequest.getTitle();
-		this.content = postRequest.getContent();
-		this.category = postRequest.getCategory();
+		this.title = postRequest.title();
+		this.content = postRequest.content();
+		this.category = postRequest.category();
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/mapper/PostMapper.java
@@ -1,0 +1,48 @@
+package com.clover.habbittracker.domain.post.mapper;
+
+import static org.mapstruct.ReportingPolicy.*;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.Named;
+
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.like.entity.Like;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
+import com.clover.habbittracker.domain.post.dto.PostResponse;
+import com.clover.habbittracker.domain.post.entity.Post;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = IGNORE)
+public interface PostMapper {
+
+
+	Post toPost(PostRequest request, Member member);
+
+	@Mappings({
+		@Mapping(source = "post.comments",target = "numOfComments", qualifiedByName = "commentsToSize"),
+		@Mapping(source = "post.likes",target = "numOfLikes", qualifiedByName = "likesToSize"),
+		@Mapping(source = "post.createdAt", target = "createDate")
+	})
+	PostResponse toPostResponse(Post post);
+
+	@Mappings({
+		@Mapping(source = "post.createdAt", target = "createDate"),
+		@Mapping(source = "post.updatedAt", target = "updateDate")
+	})
+	PostDetailResponse toPostDetail(Post post);
+
+	@Named("commentsToSize")
+	static Integer commentsToSize(List<Comment> comments) {
+		return comments.size();
+	}
+
+	@Named("likesToSize")
+	static Integer likesToSize(List<Like> likes) {
+		return likes.size();
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -16,6 +16,7 @@ import com.clover.habbittracker.domain.post.dto.PostResponse;
 import com.clover.habbittracker.domain.post.entity.Category;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.exception.PostNotFoundException;
+import com.clover.habbittracker.domain.post.mapper.PostMapper;
 import com.clover.habbittracker.domain.post.repository.PostRepository;
 import com.clover.habbittracker.global.exception.PermissionDeniedException;
 
@@ -29,15 +30,12 @@ public class PostServiceImpl implements PostService {
 
 	private final MemberRepository memberRepository;
 
+	private final PostMapper postMapper;
+
 	@Transactional
 	public Long register(Long memberId, PostRequest request) {
 		Member member = getMemberBy(memberId);
-		Post post = Post.builder()
-			.title(request.getTitle())
-			.content(request.getContent())
-			.category(request.getCategory())
-			.member(member)
-			.build();
+		Post post = postMapper.toPost(request, member);
 		Post savedPost = postRepository.save(post);
 
 		return savedPost.getId();
@@ -49,14 +47,14 @@ public class PostServiceImpl implements PostService {
 		Post post = postRepository.joinCommentAndLikeFindById(postId)
 			.orElseThrow(() -> new PostNotFoundException(postId));
 		postRepository.updateViews(post.getId());
-		return PostDetailResponse.from(post);
+		return postMapper.toPostDetail(post);
 
 	}
 
 	@Override
 	public List<PostResponse> getPostList(Pageable pageable, Category category) {
 		Page<Post> postsSummary = postRepository.findAllPostsSummary(pageable, category);
-		return postsSummary.stream().map(PostResponse::from).toList();
+		return postsSummary.stream().map(postMapper::toPostResponse).toList();
 	}
 
 	@Override
@@ -65,7 +63,7 @@ public class PostServiceImpl implements PostService {
 		Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(postId));
 		verifyPermissions(post.getMember(), memberId);
 		post.updatePost(request);
-		return PostResponse.from(post);
+		return postMapper.toPostResponse(post);
 	}
 
 	@Override

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -29,17 +29,18 @@ public class PostServiceImpl implements PostService {
 
 	private final MemberRepository memberRepository;
 
+	@Transactional
 	public Long register(Long memberId, PostRequest request) {
-		Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+		Member member = getMemberBy(memberId);
 		Post post = Post.builder()
 			.title(request.getTitle())
 			.content(request.getContent())
 			.category(request.getCategory())
 			.member(member)
 			.build();
-		postRepository.save(post);
+		Post savedPost = postRepository.save(post);
 
-		return post.getId();
+		return savedPost.getId();
 	}
 
 	@Override
@@ -79,5 +80,10 @@ public class PostServiceImpl implements PostService {
 		if (!member.getId().equals(memberId)) {
 			throw new PermissionDeniedException(memberId);
 		}
+	}
+
+	private Member getMemberBy(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberNotFoundException(memberId));
 	}
 }


### PR DESCRIPTION
# 작업 사항

- Post 업데이트 Http Status 201 -> 200 으로 수정하였습니다.
- 코드 가독성을 위해 매개변수 하나당 내려쓰기 한줄씩으로 변경하였습니다.
- 구체적인 반환 타입을 알기 위해 ApiResponse.success() 를 변수로 지정하였습니다.
- Post 를 등록 후 빌더로 생성한 post 의 아이디를 반환하는 것이 아닌 .save() 로 저장된 post 의 id 를 반환하도록 수정했습니다.
- 멤버Id 를 통해 Member 를 가져오는 메서드를 따로 추가했습니다.
- PostRequest 의 접근제어자가 default 로 설정되어있어, private 로 변경하였습니다.
- Insert 시 트랜잭션을 추가하였습니다.

# 특이사항

[feat(Post) : Record 추가 및 Mapstruct 추가](https://github.com/Clover-Habiters/backend/commit/7b229f8f399545bccebe7b4b77ed8fe7769ca4c0) 
- 간결한 코드를 작성하고자 Record 로 변경했습니다.
- 반복적인 객체 매핑에서 오류와 수정을 줄이고자 정적 팩터리 메서드에서 Mapstruct 를 사용하도록 변경하였습니다.
- Record 는 컴파일러가 자동으로 생성자, 접근 메서드를 생성하므로 @getter,@builder 에노테이션을 제거하였습니다.

[feat(Post) : PostMapper 추가](https://github.com/Clover-Habiters/backend/commit/052e465a90389b282989a8eb46f351629bb4ff11) 
- Mapstruct 를 사용하기 위한 인터페이스를 추가하였습니다.
- 스프링 빈 컨테이너에 담아 사용하도록 설정했습니다.
- source 는 없지만 target 필드가 존재 할때는 무시하고 매핑하도록 설정했습니다.
- PostService 구현에서 정적 팩터리 메서드를 모두 Mapper 를 사용하도록 변경하였습니다.