### PR TITLE
[#21] Feat: 검색 기능 구현

### DIFF
--- a/.github/workflows/CD-Deploy.yml
+++ b/.github/workflows/CD-Deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
       # 도커 MYSQL 이미지 실행
       - name: Create Mysql Docker Container
-        run: sudo docker run -d -p 3310:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_DATASOURCE_PASSWORD }}" mysql:8.0.31
+        run: sudo docker run -d -p 3310:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_ROOT_PASSWORD }}" mysql:8.0.31
 
       # 빌드
       - name: Build with Gradle

--- a/.github/workflows/CD-Deploy.yml
+++ b/.github/workflows/CD-Deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
       # 도커 MYSQL 이미지 실행
       - name: Create Mysql Docker Container
-        run: sudo docker run -d -p 3309:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_DATASOURCE_PASSWORD }}" mysql:8.0.31
+        run: sudo docker run -d -p 3310:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_DATASOURCE_PASSWORD }}" mysql:8.0.31
 
       # 빌드
       - name: Build with Gradle

--- a/.github/workflows/CD-Deploy.yml
+++ b/.github/workflows/CD-Deploy.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Set up Environment
         run: echo "${{ secrets.ENV }}" > ./.env # GitHub SecretKey 에서 설정한 내용으로 .env 파일 생성
 
+      # 도커 MYSQL 이미지 실행
+      - name: Create Mysql Docker Container
+        run: sudo docker run -d -p 3309:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_DATASOURCE_PASSWORD }}" mysql:8.0.31
+
       # 빌드
       - name: Build with Gradle
         run: ./gradlew clean bootJar

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
         uses: crate-ci/typos@v1.0.4
         with:
           files: 'src/**'
+
       ## 테스트 커버리지 리포트 작성
       - name: register test coverage as a comment in PR
         id: jacoco

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
 
       # 도커 MYSQL 이미지 실행
       - name: Create Mysql Docker Container
-        run: sudo docker run -d -p 3310:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_DATASOURCE_PASSWORD }}" mysql:8.0.31
+        run: sudo docker run -d -p 3310:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_ROOT_PASSWORD }}" mysql:8.0.31
 
       ## Gradle 빌드 실행
       - name: run gradle build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,10 @@ jobs:
       - name: grant permission to execute gradle command
         run: chmod +x gradlew
 
+      # 도커 MYSQL 이미지 실행
+      - name: Create Mysql Docker Container
+        run: sudo docker run -d -p 3310:3306 --env MYSQL_DATABASE="${{ secrets.TEST_DATABASE }}" --env MYSQL_ROOT_PASSWORD="${{ secrets.TEST_DATASOURCE_PASSWORD }}" mysql:8.0.31
+
       ## Gradle 빌드 실행
       - name: run gradle build
         run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java'
+    id 'jacoco'
     id 'org.springframework.boot' version '3.0.5'
     id 'io.spring.dependency-management' version '1.1.0'
-    id 'jacoco'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.clover'
-version = '1.0.0'
+version = '1.1.0'
 sourceCompatibility = '17'
 
 configurations {
@@ -22,31 +22,39 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'javax.xml.bind:jaxb-api:2.3.0'
-    implementation 'com.mysql:mysql-connector-j:8.0.32'
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
-    runtimeOnly 'com.h2database:h2'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // DB - MySQL, H2
+    implementation 'com.mysql:mysql-connector-j:8.0.32'
+    runtimeOnly 'com.h2database:h2'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     // QueryDSL (Boot 3.x)
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation 'javax.xml.bind:jaxb-api:2.3.0' // ??
 
-    //mapstruct  * Lombok 의 getter, setter, builder 를 이용하여 생성되므로 Lombok 먼저 의존성 주입 후 사용해야함.
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+    // Mapstruct  * Lombok 의 getter, setter, builder 를 이용하여 생성되므로 Lombok 먼저 의존성 주입 후 사용해야함.
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 
-    // spring restdocs
+    // Spring Restdocs
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
@@ -54,6 +62,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // Embedded Redis
     testImplementation 'it.ozimov:embedded-redis:0.7.2'
+
+    // AWS - S3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
+
+    // Slack
+    implementation "net.gpedro.integrations.slack:slack-webhook:1.4.0"
+
+    // Bucket4j - 처리율 제한
+    implementation 'com.bucket4j:bucket4j-core:8.3.0'
 }
 
 /*jacoco 설정*/
@@ -70,11 +87,11 @@ jacocoTestCoverageVerification {
     violationRules {
         rule {
             enabled = true
-            excludes = [
-                    '*.global.security.oauth*',
-                    '*.global.util*',
-                    '*.global.dto*',
-                    '*.global.exception*'
+            excludes = [ // 제외할 패키지
+                         '*.global.security.oauth*',
+                         '*.global.util*',
+                         '*.global.dto*',
+                         '*.global.exception*'
             ]
 
         }
@@ -88,6 +105,7 @@ tasks.named('test') {
     finalizedBy 'jacocoTestReport'
 }
 
+/*asciidoctor 설정*/
 ext {
     snippetsDir = file('build/generated-snippets')
 }
@@ -124,5 +142,4 @@ task copyDocument(type: Copy) {
 build {
     dependsOn copyDocument
 }
-
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-
     // QueryDSL (Boot 3.x)
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
@@ -94,10 +93,10 @@ ext {
 }
 
 asciidoctor {
-    attributes 'snippets' : snippetsDir
+    attributes 'snippets': snippetsDir
     configurations 'asciidoctorExtensions'
     forkOptions {
-        jvmArgs('--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED','--add-opens','java.base/java.io=ALL-UNNAMED')
+        jvmArgs('--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED')
     }
     dependsOn test
     inputs.dir snippetsDir

--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.*;
 import java.net.URI;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -23,10 +24,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostResponse;
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
+import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.service.PostService;
 import com.clover.habbittracker.global.base.dto.ApiResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -50,9 +53,9 @@ public class PostController {
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<PostResponse>>> getPostList(
 		@PageableDefault(size = 15) Pageable pageable,
-		@RequestParam(required = false) Category category
+		@RequestParam(required = false) Post.Category category
 	) {
-		List<PostResponse> postList = postService.getPostList(pageable, category);
+		List<PostResponse> postList = postService.getPostAllBy(category, pageable);
 		ApiResponse<List<PostResponse>> response = ApiResponse.success(postList);
 		return ResponseEntity.ok().body(response);
 	}
@@ -61,8 +64,19 @@ public class PostController {
 	public ResponseEntity<ApiResponse<PostDetailResponse>> getPost(
 		@PathVariable Long postId
 	) {
-		PostDetailResponse postDetail = postService.getPost(postId);
+		PostDetailResponse postDetail = postService.getPostBy(postId);
 		ApiResponse<PostDetailResponse> response = ApiResponse.success(postDetail);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<Page<PostResponse>>> searchPost(
+		@PageableDefault(size = 15) Pageable pageable,
+		@Valid @RequestBody PostSearchCondition postSearchCondition
+	) {
+		Page<PostResponse> postPages = postService.getPostBy(postSearchCondition, pageable);
+		ApiResponse<Page<PostResponse>> response = ApiResponse.success(postPages);
+
 		return ResponseEntity.ok().body(response);
 	}
 
@@ -87,5 +101,4 @@ public class PostController {
 		postService.deletePost(postId, memberId);
 		return ApiResponse.success();
 	}
-
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
@@ -5,12 +5,12 @@ import java.util.List;
 
 import com.clover.habbittracker.domain.comment.dto.CommentResponse;
 import com.clover.habbittracker.domain.emoji.entity.Emoji;
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.entity.Post;
 
 public record PostDetailResponse(
 	String title,
 	String content,
-	Category category,
+	Post.Category category,
 	Long views,
 	List<CommentResponse> comments,
 	List<Emoji> emojis,

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostRequest.java
@@ -1,11 +1,11 @@
 package com.clover.habbittracker.domain.post.dto;
 
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.entity.Post;
 
 public record PostRequest(
 	String title,
 	String content,
-	Category category
+	Post.Category category
 ) {
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
@@ -2,13 +2,13 @@ package com.clover.habbittracker.domain.post.dto;
 
 import java.time.LocalDateTime;
 
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.entity.Post;
 
 public record PostResponse(
 	Long id,
 	String title,
 	String content,
-	Category category,
+	Post.Category category,
 	Long views,
 	Integer numOfComments,
 	Integer numOfEmojis,

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostSearchCondition.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostSearchCondition.java
@@ -19,6 +19,7 @@ public class PostSearchCondition {
 	private Post.Category category;
 	private SearchType searchType;
 	private String keyword;
+
 	public enum SearchType {
 		ALL, TITLE, CONTENT;
 

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostSearchCondition.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostSearchCondition.java
@@ -1,0 +1,38 @@
+package com.clover.habbittracker.domain.post.dto;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSearchCondition {
+
+	private Post.Category category;
+	private SearchType searchType;
+	private String keyword;
+	public enum SearchType {
+		ALL, TITLE, CONTENT;
+
+		@JsonCreator
+		public static SearchType of(String searchTypeName) {
+			return Arrays.stream(SearchType.values())
+				.filter(value -> Objects.equals(value.name(), searchTypeName.toUpperCase()))
+				.findFirst()
+				.orElseThrow();
+		}
+
+		@JsonValue
+		public String getName() {
+			return this.name();
+		}
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostSimpleResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostSimpleResponse.java
@@ -1,6 +1,5 @@
 package com.clover.habbittracker.domain.post.dto;
 
-import com.clover.habbittracker.domain.post.entity.Category;
 import com.clover.habbittracker.domain.post.entity.Post;
 
 import lombok.Builder;
@@ -12,7 +11,7 @@ public class PostSimpleResponse {
 
 	private Long id;
 	private String title;
-	private Category category;
+	private Post.Category category;
 
 	public static PostSimpleResponse from(Post post) {
 		return PostSimpleResponse.builder()

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Category.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Category.java
@@ -1,6 +1,0 @@
-package com.clover.habbittracker.domain.post.entity;
-
-public enum Category {
-	STUDY, EXERCISE, HEALTH, DAILY, ETC
-}
-

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -58,7 +58,6 @@ public class Post extends BaseEntity {
 	@ManyToOne
 	@JoinColumn(name = "memberId")
 	private Member member;
-
 	@Builder
 	public Post(String title, String content, Category category, Member member) {
 		this.title = title;
@@ -72,5 +71,9 @@ public class Post extends BaseEntity {
 		this.title = postRequest.title();
 		this.content = postRequest.content();
 		this.category = postRequest.category();
+	}
+
+	public enum Category {
+		ALL, STUDY, EXERCISE, HEALTH, DAILY, ETC
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
@@ -1,18 +1,21 @@
 package com.clover.habbittracker.domain.post.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
 import com.clover.habbittracker.domain.post.entity.Post;
 
 public interface PostCustomRepository {
-	Page<Post> findAllPostsSummary(Pageable pageable, Category category);
+	List<Post> findAllPostsSummary(Pageable pageable, Post.Category category);
 
 	Optional<Post> joinCommentAndLikeFindById(@Param("postId") Long postId);
 
 	Long updateViews(Long postId);
+
+	Page<Post> searchPostBy(PostSearchCondition postSearchCondition, Pageable pageable);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.clover.habbittracker.domain.post.repository;
 
 import static com.clover.habbittracker.domain.comment.entity.QComment.*;
 import static com.clover.habbittracker.domain.member.entity.QMember.*;
+import static com.clover.habbittracker.domain.post.dto.PostSearchCondition.SearchType.*;
 import static com.clover.habbittracker.domain.post.entity.QPost.*;
 
 import java.util.List;
@@ -12,12 +13,12 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import com.clover.habbittracker.domain.comment.entity.Comment;
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -29,38 +30,25 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public Page<Post> findAllPostsSummary(Pageable pageable, Category category) {
+	public List<Post> findAllPostsSummary(Pageable pageable, Post.Category category) {
 
-		List<Post> content = jpaQueryFactory.selectFrom(post)
+		return jpaQueryFactory.selectFrom(post)
 			.leftJoin(post.member, member).fetchJoin()
 			.where(eqCategory(category))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.orderBy(post.createdAt.desc())
 			.fetch();
-
-		Long count = getCount();
-
-		return new PageImpl<>(content, pageable, count);
 	}
 
 	@Override
 	public Optional<Post> joinCommentAndLikeFindById(Long postId) {
-
-		JPQLQuery<Comment> commentSubQuery = JPAExpressions
-			.selectFrom(comment)
-			.where(comment.parentId.isNull());
-
-
 		Post result = jpaQueryFactory.selectFrom(post)
 			.leftJoin(post.member, member)
 			.fetchJoin()
 			.leftJoin(post.comments, comment)
 			.fetchJoin()
-			.where(
-				eqId(postId)
-					.and(comment.in(commentSubQuery))
-			)
+			.where(eqId(postId))
 			.fetchOne();
 		return Optional.ofNullable(result);
 	}
@@ -73,6 +61,26 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 			.execute();
 	}
 
+	@Override
+	public Page<Post> searchPostBy(PostSearchCondition postSearchCondition, Pageable pageable) {
+
+		List<Post> content = jpaQueryFactory.selectFrom(post)
+			.leftJoin(post.member, member).fetchJoin()
+			.where(
+				eqFilter(postSearchCondition.getCategory()),
+				matchKeyword(postSearchCondition.getSearchType(), postSearchCondition.getKeyword())
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(post.createdAt.desc())
+			.distinct()
+			.fetch();
+
+		Integer count = getCount();
+
+		return new PageImpl<>(content, pageable, count);
+	}
+
 	private BooleanExpression eqId(Long postId) {
 		if (postId != null) {
 			return post.id.eq(postId);
@@ -80,16 +88,51 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 		return null;
 	}
 
-	private BooleanExpression eqCategory(Category category) {
+	private BooleanExpression eqCategory(Post.Category category) {
 		if (category != null) {
 			return post.category.eq(category);
 		}
 		return null;
 	}
 
-	private Long getCount() {
+	private BooleanExpression eqFilter(Post.Category category) {
+		if (category == null || Post.Category.ALL.equals(category)) {
+			return null;
+		}
+		return post.category.eq(category);
+	}
+
+	private Integer getCount() {
 		return jpaQueryFactory.select(post.count())
 			.from(post)
-			.fetchOne();
+			.fetch().size();
+	}
+
+	private BooleanExpression matchKeyword(PostSearchCondition.SearchType searchType, String keyword) {
+		if (isNotValid(keyword)) {
+			return null;
+		} else if (searchType == TITLE) {
+			NumberExpression<Double> booleanTemplate = Expressions.numberTemplate(Double.class,
+				"function('match',{0},{1})", post.title, keyword);
+			return booleanTemplate.gt(0);
+		} else if (searchType == CONTENT) {
+			NumberTemplate<Double> booleanTemplate = Expressions.numberTemplate(Double.class,
+				"function('match',{0},{1})", post.content, keyword);
+			return booleanTemplate.gt(0);
+		} else { // TODO: 하나로 합쳐서 검색 / 나눠서 검색해서 합치기?
+			NumberExpression<Double> booleanTemplate = Expressions.numberTemplate(Double.class,
+				"function('match',{0},{1})", post.title, keyword);
+
+			NumberExpression<Double> booleanTemplate2 = Expressions.numberTemplate(Double.class,
+				"function('match',{0},{1})", post.content, keyword);
+
+			BooleanExpression result = booleanTemplate.gt(0).or(booleanTemplate2.gt(0));
+
+			return result;
+		}
+	}
+
+	private boolean isNotValid(String keyword) {
+		return keyword == null || keyword.isBlank() || keyword.length() < 2;
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
@@ -2,19 +2,23 @@ package com.clover.habbittracker.domain.post.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostResponse;
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
+import com.clover.habbittracker.domain.post.entity.Post;
 
 public interface PostService {
 	Long register(Long memberId, PostRequest request);
 
-	PostDetailResponse getPost(Long postId);
+	PostDetailResponse getPostBy(Long postId);
 
-	List<PostResponse> getPostList(Pageable pageable, Category category);
+	List<PostResponse> getPostAllBy(Post.Category category, Pageable pageable);
+
+	Page<PostResponse> getPostBy(PostSearchCondition postSearchCondition, Pageable pageable);
 
 	PostResponse updatePost(Long postId, PostRequest request, Long memberId);
 

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -13,7 +13,7 @@ import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.dto.PostResponse;
-import com.clover.habbittracker.domain.post.entity.Category;
+import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.exception.PostNotFoundException;
 import com.clover.habbittracker.domain.post.mapper.PostMapper;
@@ -43,7 +43,7 @@ public class PostServiceImpl implements PostService {
 
 	@Override
 	@Transactional
-	public PostDetailResponse getPost(Long postId) {
+	public PostDetailResponse getPostBy(Long postId) {
 		Post post = postRepository.joinCommentAndLikeFindById(postId)
 			.orElseThrow(() -> new PostNotFoundException(postId));
 		postRepository.updateViews(post.getId());
@@ -52,8 +52,16 @@ public class PostServiceImpl implements PostService {
 	}
 
 	@Override
-	public List<PostResponse> getPostList(Pageable pageable, Category category) {
-		Page<Post> postsSummary = postRepository.findAllPostsSummary(pageable, category);
+	public Page<PostResponse> getPostBy(PostSearchCondition postSearchCondition, Pageable pageable) {
+
+		Page<Post> searchedPost = postRepository.searchPostBy(postSearchCondition, pageable);
+
+		return searchedPost.map(postMapper::toPostResponse);
+	}
+
+	@Override
+	public List<PostResponse> getPostAllBy(Post.Category category, Pageable pageable) {
+		List<Post> postsSummary = postRepository.findAllPostsSummary(pageable, category);
 		return postsSummary.stream().map(postMapper::toPostResponse).toList();
 	}
 

--- a/src/main/java/com/clover/habbittracker/global/config/db/JpaConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/config/db/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.global.config;
+package com.clover.habbittracker.global.config.db;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/clover/habbittracker/global/config/db/MySQLConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/config/db/MySQLConfig.java
@@ -1,0 +1,49 @@
+package com.clover.habbittracker.global.config.db;
+
+import org.hibernate.dialect.DatabaseVersion;
+import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.query.spi.QueryEngine;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.type.BasicTypeRegistry;
+import org.hibernate.type.StandardBasicTypes;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MySQLConfig {
+
+	@Bean
+	public MySQLDialect mySQLCustomDialect() {
+		return new MySQLCustomDialect();
+	}
+
+	public static class MySQLCustomDialect extends MySQLDialect {
+
+		public MySQLCustomDialect() {
+			super(DatabaseVersion.make(8, 0, 13));
+		}
+
+		@Override
+		public void initializeFunctionRegistry(QueryEngine queryEngine) {
+			super.initializeFunctionRegistry(queryEngine);
+			BasicTypeRegistry basicTypeRegistry = queryEngine.getTypeConfiguration().getBasicTypeRegistry();
+			SqmFunctionRegistry functionRegistry = queryEngine.getSqmFunctionRegistry();
+
+			functionRegistry.registerPattern( // 1개 매칭
+				"match",
+				"match(?1) against (?2 in boolean mode)",
+				basicTypeRegistry.resolve(StandardBasicTypes.DOUBLE)
+			);
+
+			functionRegistry.registerPattern( // 2개 매칭
+				"matches",
+				"match(?1, ?2) against (?3 in boolean mode)",
+				basicTypeRegistry.resolve(StandardBasicTypes.DOUBLE)
+			);
+		}
+	}
+
+}
+
+
+

--- a/src/main/java/com/clover/habbittracker/global/config/db/RedisConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/config/db/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.global.config;
+package com.clover.habbittracker.global.config.db;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/clover/habbittracker/global/config/web/WebConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/config/web/WebConfig.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.global.config;
+package com.clover.habbittracker.global.config.web;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -7,12 +7,12 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig{
+public class WebConfig {
 	@Bean
-	WebMvcConfigurer webMvcConfigurer(){
+	WebMvcConfigurer webMvcConfigurer() {
 
 		return new WebMvcConfigurer() {
-			public void addCorsMappings(CorsRegistry registry){
+			public void addCorsMappings(CorsRegistry registry) {
 				registry.addMapping("/**")
 					.allowedOrigins("*")
 					.allowedMethods(
@@ -24,6 +24,5 @@ public class WebConfig{
 			}
 		};
 	}
-
 
 }

--- a/src/main/java/com/clover/habbittracker/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clover/habbittracker/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.global.exception;
 
-import static com.clover.habbittracker.global.util.MyLogger.*;
+import static com.clover.habbittracker.global.log.MyLogger.*;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;

--- a/src/main/java/com/clover/habbittracker/global/log/MyLogger.java
+++ b/src/main/java/com/clover/habbittracker/global/log/MyLogger.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.global.util;
+package com.clover.habbittracker.global.log;
 
 import static org.springframework.web.servlet.HandlerMapping.*;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
       hibernate:
         format_sql: true
         globally_quoted_identifiers: true
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+    dialect: com.clover.habbittracker.global.config.db.MySQLConfig.MySQLCustomDialect
 
   # redis
   redis:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -73,7 +73,10 @@ create table post
     member_id    bigint       null,
     created_date datetime(6)  not null default CURRENT_TIMESTAMP(6),
     updated_date datetime(6)  not null default CURRENT_TIMESTAMP(6),
-    deleted      boolean      not null default false
+    deleted      boolean      not null default false,
+
+    FULLTEXT INDEX post_title (title),
+    FULLTEXT INDEX post_content (content)
 );
 
 create table comment
@@ -117,4 +120,3 @@ create table bookmark_folder
     bookmark_id bigint null,
     posts_id    bigint null
 );
-

--- a/src/test/java/com/clover/habbittracker/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -19,7 +19,7 @@ import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.repository.PostRepository;
-import com.clover.habbittracker.global.config.JpaConfig;
+import com.clover.habbittracker.global.config.db.JpaConfig;
 
 @Import({JpaConfig.class})
 @DataJpaTest

--- a/src/test/java/com/clover/habbittracker/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -21,8 +22,9 @@ import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.repository.PostRepository;
 import com.clover.habbittracker.global.config.db.JpaConfig;
 
-@Import({JpaConfig.class})
 @DataJpaTest
+@Import(JpaConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class BookmarkRepositoryTest {
 
 	@Autowired

--- a/src/test/java/com/clover/habbittracker/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/repository/CommentRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -23,7 +24,8 @@ import com.clover.habbittracker.global.util.MemberProvider;
 
 @DataJpaTest
 @Import(JpaConfig.class)
-public class CommentRepositoryTest {
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentRepositoryTest {
 
 	@Autowired
 	private CommentRepository commentRepository;

--- a/src/test/java/com/clover/habbittracker/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/repository/CommentRepositoryTest.java
@@ -18,92 +18,92 @@ import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.repository.PostRepository;
-import com.clover.habbittracker.global.config.JpaConfig;
+import com.clover.habbittracker.global.config.db.JpaConfig;
 import com.clover.habbittracker.global.util.MemberProvider;
 
 @DataJpaTest
 @Import(JpaConfig.class)
 public class CommentRepositoryTest {
 
-    @Autowired
-    private CommentRepository commentRepository;
+	@Autowired
+	private CommentRepository commentRepository;
 
-    @Autowired
-    private PostRepository postRepository;
+	@Autowired
+	private PostRepository postRepository;
 
-    @Autowired
-    private MemberRepository memberRepository;
+	@Autowired
+	private MemberRepository memberRepository;
 
-    private Member testMember;
+	private Member testMember;
 
-    private Post testPost;
+	private Post testPost;
 
-    @BeforeEach
-    void setUp() {
-        Member member = MemberProvider.createTestMember();
-        testMember = memberRepository.save(member);
+	@BeforeEach
+	void setUp() {
+		Member member = MemberProvider.createTestMember();
+		testMember = memberRepository.save(member);
 
-        testPost = postRepository.save(createTestPost(member));
-    }
+		testPost = postRepository.save(createTestPost(member));
+	}
 
-    @Test
-    @DisplayName("댓글을 등록 할 수 있다.")
-    void saveCommentTest() {
-        //given
-        Comment testComment = Comment.builder()
-                .content("testComment")
-                .post(testPost)
-                .member(testMember)
-                .build();
-        //when
-        Comment saveComment = commentRepository.save(testComment);
-        //then
-        assertThat(testComment).usingRecursiveComparison().isEqualTo(saveComment);
-    }
+	@Test
+	@DisplayName("댓글을 등록 할 수 있다.")
+	void saveCommentTest() {
+		//given
+		Comment testComment = Comment.builder()
+			.content("testComment")
+			.post(testPost)
+			.member(testMember)
+			.build();
+		//when
+		Comment saveComment = commentRepository.save(testComment);
+		//then
+		assertThat(testComment).usingRecursiveComparison().isEqualTo(saveComment);
+	}
 
-    @Test
-    @DisplayName("댓글 아이디와 게시글 아이디로 댓글을 조회 할 수 있다.")
-    void findByIdAndPostIdTest() {
-        //given
-        Comment testComment = Comment.builder()
-                .content("testComment")
-                .post(testPost)
-                .member(testMember)
-                .build();
-        Comment saveComment = commentRepository.save(testComment);
+	@Test
+	@DisplayName("댓글 아이디와 게시글 아이디로 댓글을 조회 할 수 있다.")
+	void findByIdAndPostIdTest() {
+		//given
+		Comment testComment = Comment.builder()
+			.content("testComment")
+			.post(testPost)
+			.member(testMember)
+			.build();
+		Comment saveComment = commentRepository.save(testComment);
 
-        //when
-        Optional<Comment> findComment = commentRepository.findByIdAndPostId(saveComment.getId(), testPost.getId());
+		//when
+		Optional<Comment> findComment = commentRepository.findByIdAndPostId(saveComment.getId(), testPost.getId());
 
-        //then
-        assertThat(findComment).isPresent();
-        assertThat(findComment.get()).usingRecursiveComparison().isEqualTo(saveComment);
-    }
+		//then
+		assertThat(findComment).isPresent();
+		assertThat(findComment.get()).usingRecursiveComparison().isEqualTo(saveComment);
+	}
 
-    @Test
-    @DisplayName("댓글의 부모 아이디로 대댓글 리스트를 조회 할 수 있다.")
-    void findByParentIdTest() {
-        //given
-        Comment testComment = Comment.builder()
-                .content("testComment")
-                .post(testPost)
-                .member(testMember)
-                .build();
-        Comment saveComment = commentRepository.save(testComment);
-        Comment reply = Comment.builder()
-                .content("testReply")
-                .member(testMember)
-                .post(testPost)
-                .parentId(saveComment.getId())
-                .build();
-        //when
-        List<Comment> childCommentById = commentRepository.findChildCommentById(saveComment.getId());
+	@Test
+	@DisplayName("댓글의 부모 아이디로 대댓글 리스트를 조회 할 수 있다.")
+	void findByParentIdTest() {
+		//given
+		Comment testComment = Comment.builder()
+			.content("testComment")
+			.post(testPost)
+			.member(testMember)
+			.build();
+		Comment saveComment = commentRepository.save(testComment);
+		Comment reply = Comment.builder()
+			.content("testReply")
+			.member(testMember)
+			.post(testPost)
+			.parentId(saveComment.getId())
+			.build();
+		//when
+		List<Comment> childCommentById = commentRepository.findChildCommentById(saveComment.getId());
 
-        //then
-        childCommentById
-                .forEach(childComment -> {
-                    assertThat(childComment.getParentId()).isEqualTo(saveComment.getId());
-                    assertThat(childComment.getContent()).isEqualTo(reply.getContent());
-                });
-    }
+		//then
+		childCommentById
+			.forEach(childComment -> {
+				assertThat(childComment.getParentId()).isEqualTo(saveComment.getId());
+				assertThat(childComment.getContent()).isEqualTo(reply.getContent());
+			});
+	}
 }

--- a/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Import;
 import com.clover.habbittracker.domain.diary.entity.Diary;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
-import com.clover.habbittracker.global.config.JpaConfig;
+import com.clover.habbittracker.global.config.db.JpaConfig;
 import com.clover.habbittracker.global.util.DateUtil;
 
 @DataJpaTest

--- a/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -23,7 +24,8 @@ import com.clover.habbittracker.global.util.DateUtil;
 
 @DataJpaTest
 @Import(JpaConfig.class)
-public class DiaryRepositoryTest {
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class DiaryRepositoryTest {
 
 	@Autowired
 	private DiaryRepository diaryRepository;

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +34,6 @@ import com.clover.habbittracker.domain.habitcheck.entity.HabitCheck;
 import com.clover.habbittracker.domain.habitcheck.repository.HabitCheckRepository;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
-import com.clover.habbittracker.global.config.JpaConfig;
 import com.clover.habbittracker.global.exception.ErrorType;
 import com.clover.habbittracker.global.security.jwt.JwtProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,6 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureRestDocs(uriScheme = "https", uriHost = "api.habiters.store")
 public class HabitControllerTest {
 
+	private final ObjectMapper mapper = new ObjectMapper();
 	@Autowired
 	private MockMvc mockMvc;
 	@Autowired
@@ -56,12 +55,8 @@ public class HabitControllerTest {
 	private JwtProvider jwtProvider;
 	@Autowired
 	private HabitCheckRepository habitCheckRepository;
-
 	private String accessJwt;
-
 	private Habit testHabit;
-
-	private final ObjectMapper mapper = new ObjectMapper();
 
 	@BeforeEach
 	void setUp() {
@@ -146,7 +141,7 @@ public class HabitControllerTest {
 	void deleteHabitTest() throws Exception {
 		//when then
 		mockMvc.perform(
-				RestDocumentationRequestBuilders.delete("/habits/{habitId}" , testHabit.getId())
+				RestDocumentationRequestBuilders.delete("/habits/{habitId}", testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
 			.andDo(document("habit-delete",
@@ -162,7 +157,7 @@ public class HabitControllerTest {
 					fieldWithPath("code").type(STRING).description("결과 코드"),
 					fieldWithPath("message").type(STRING).description("결과 메시지")
 				)
-				));
+			));
 	}
 
 	@Test
@@ -174,7 +169,7 @@ public class HabitControllerTest {
 		String request = mapper.writeValueAsString(new HabitCheckRequest(today));
 		//when then
 		mockMvc.perform(
-				RestDocumentationRequestBuilders.post("/habits/{habitId}/check"  ,testHabit.getId())
+				RestDocumentationRequestBuilders.post("/habits/{habitId}/check", testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -255,6 +250,7 @@ public class HabitControllerTest {
 				)
 			));
 	}
+
 	@Test
 	@DisplayName("사용자는 나의 습관 리스트와 습관 수행 여부를 월 별로 조회 할 수 있다.")
 	void monthlyMyHabitListTest() throws Exception {
@@ -267,7 +263,7 @@ public class HabitControllerTest {
 		//when then
 		mockMvc.perform(
 				get("/habits")
-					.header("Authorization", "Bearer " + accessJwt).param("date",date))
+					.header("Authorization", "Bearer " + accessJwt).param("date", date))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.[0].id").exists())
 			.andExpect(jsonPath("$.data.[0].content").exists())
@@ -334,13 +330,13 @@ public class HabitControllerTest {
 		String request = mapper.writeValueAsString(new HabitCheckRequest(today));
 		//when then
 		mockMvc.perform(
-			post("/habits/{habitId}/check" , testHabit.getId())
+			post("/habits/{habitId}/check", testHabit.getId())
 				.header("Authorization", "Bearer " + accessJwt)
 				.contentType(APPLICATION_JSON)
 				.content(request));
 
 		mockMvc.perform(
-				RestDocumentationRequestBuilders.post("/habits/{habitId}/check" , testHabit.getId())
+				RestDocumentationRequestBuilders.post("/habits/{habitId}/check", testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -362,6 +358,7 @@ public class HabitControllerTest {
 				)));
 
 	}
+
 	@Test
 	@DisplayName("습관 수행 여부를 체크 할 경우 과거 또는 미래를 체크 할 경우 HabitExpiredException 예외가 터진다.")
 	void habitCheckTestWithExpiredDate() throws Exception {
@@ -372,11 +369,11 @@ public class HabitControllerTest {
 
 		//when then
 		mockMvc.perform(
-			post("/habits/{habitId}/check" , testHabit.getId())
+			post("/habits/{habitId}/check", testHabit.getId())
 				.header("Authorization", "Bearer " + accessJwt));
 
 		mockMvc.perform(
-				RestDocumentationRequestBuilders.post("/habits/{habitId}/check" , testHabit.getId())
+				RestDocumentationRequestBuilders.post("/habits/{habitId}/check", testHabit.getId())
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))

--- a/src/test/java/com/clover/habbittracker/domain/habit/repository/HabitRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/repository/HabitRepositoryTest.java
@@ -18,7 +18,7 @@ import com.clover.habbittracker.domain.habitcheck.entity.HabitCheck;
 import com.clover.habbittracker.domain.habitcheck.repository.HabitCheckRepository;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
-import com.clover.habbittracker.global.config.JpaConfig;
+import com.clover.habbittracker.global.config.db.JpaConfig;
 
 @DataJpaTest
 @Import(JpaConfig.class)

--- a/src/test/java/com/clover/habbittracker/domain/habit/repository/HabitRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/repository/HabitRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -22,7 +23,8 @@ import com.clover.habbittracker.global.config.db.JpaConfig;
 
 @DataJpaTest
 @Import(JpaConfig.class)
-public class HabitRepositoryTest {
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class HabitRepositoryTest {
 	private final HabitRepository habitRepository;
 
 	private final MemberRepository memberRepository;

--- a/src/test/java/com/clover/habbittracker/domain/habitCheck/repository/HabitCheckRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habitCheck/repository/HabitCheckRepositoryTest.java
@@ -14,7 +14,7 @@ import com.clover.habbittracker.domain.habit.entity.Habit;
 import com.clover.habbittracker.domain.habit.repository.HabitRepository;
 import com.clover.habbittracker.domain.habitcheck.entity.HabitCheck;
 import com.clover.habbittracker.domain.habitcheck.repository.HabitCheckRepository;
-import com.clover.habbittracker.global.config.JpaConfig;
+import com.clover.habbittracker.global.config.db.JpaConfig;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -40,7 +40,6 @@ public class HabitCheckRepositoryTest {
 		//then
 		assertThat(habitCheck.getHabit()).isEqualTo(testHabit);
 	}
-
 
 	@Test
 	@DisplayName("습관정보로 습관 체크 내역을 조회 할 수 있다.")

--- a/src/test/java/com/clover/habbittracker/domain/habitCheck/repository/HabitCheckRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habitCheck/repository/HabitCheckRepositoryTest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -18,6 +19,7 @@ import com.clover.habbittracker.global.config.db.JpaConfig;
 
 @DataJpaTest
 @Import(JpaConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class HabitCheckRepositoryTest {
 
 	@Autowired

--- a/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
@@ -13,9 +13,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import com.clover.habbittracker.domain.member.entity.Member;
-import com.clover.habbittracker.global.config.JpaConfig;
+import com.clover.habbittracker.global.config.db.JpaConfig;
 
-@DataJpaTest(properties = { "spring.datasource.url=jdbc:h2:mem:testdb", "spring.datasource.driver-class-name=org.h2.Driver", "spring.datasource.username=sa", "spring.datasource.password=" })
+@DataJpaTest(properties = {"spring.datasource.url=jdbc:h2:mem:testdb",
+	"spring.datasource.driver-class-name=org.h2.Driver", "spring.datasource.username=sa",
+	"spring.datasource.password="})
 @Import(JpaConfig.class)
 public class MemberRepositoryTest {
 
@@ -30,7 +32,6 @@ public class MemberRepositoryTest {
 	void setMemberData() {
 		memberRepository.save(createTestMember());
 	}
-
 
 	@Test
 	@DisplayName("사용자를 저장 할 수 있다.")

--- a/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
@@ -9,17 +9,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.global.config.db.JpaConfig;
 
-@DataJpaTest(properties = {"spring.datasource.url=jdbc:h2:mem:testdb",
-	"spring.datasource.driver-class-name=org.h2.Driver", "spring.datasource.username=sa",
-	"spring.datasource.password="})
+@DataJpaTest
 @Import(JpaConfig.class)
-public class MemberRepositoryTest {
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class MemberRepositoryTest {
 
 	private final MemberRepository memberRepository;
 

--- a/src/test/java/com/clover/habbittracker/global/util/PostProvider.java
+++ b/src/test/java/com/clover/habbittracker/global/util/PostProvider.java
@@ -1,14 +1,13 @@
 package com.clover.habbittracker.global.util;
 
 import com.clover.habbittracker.domain.member.entity.Member;
-import com.clover.habbittracker.domain.post.entity.Category;
 import com.clover.habbittracker.domain.post.entity.Post;
 
 public class PostProvider {
 
 	private static final String TITLE = "testTitle";
 	private static final String CONTENT = "testContent";
-	private static final Category CATEGORY = Category.DAILY;
+	private static final Post.Category CATEGORY = Post.Category.DAILY;
 
 	public static Post createTestPost(Member member) {
 		return Post.builder()

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,10 +1,10 @@
 spring:
   datasource:
     ## 테스트 db는 h2 메모리로 실행.
-    url: jdbc:h2:mem:test
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3310/habiters-db?serverTimezone=Asia/Seoul
+    username: ${DB_USER_NAME}
+    password: ${DB_PASSWORD}
 
   sql:
     init:
@@ -15,7 +15,7 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: none
-    database-platform: org.hibernate.dialect.H2Dialect
+    dialect: com.clover.habbittracker.global.config.db.MySQLConfig.MySQLCustomDialect
   #    defer-datasource-initialization: true
   config:
     import: application-token.yml, application-security.yml


### PR DESCRIPTION
## 작업 사항
- #21 
- MySQL `FullText Search` 기능을 통해 게시글 검색 기능을 구현했습니다.
  - QueryDSL로 FullText Search 쿼리를 사용할 수 있는 알고리즘 구현
- 검색을 위한 `DTO(PostSearchCondition)`를 추가했습니다.

### 이외
- Test DB를 인메모리에서 외부 DB로 변경했습니다.( **`포트 3310`** ) 확인바랍니다.
  -  AutoConfigureTestDatabase 속성을` Replace.NONE`으로 변경
  - `CI Script`에서 Docker로 MySQL DB를 띄워서 테스트할 수 있도록 하였음
-  config 패키지 정리 (config-db-MySQLConfig)
- build.gradle 정리
  - 버전 1.1로 변경 
- Category의 위치를 Post 엔티티 내부로 두었습니다.(보다 명확하게 하기 위해서)

## 특이사항
- 아직 테스트는 추가 못했습니다. 게시글 테스트 추가시 같이 추가하겠습니다..!
- 스타일 적용이 뒤죽박죽인데 조만간 리팩터링하면서 통일성있도록 해보겠습니다.