### PR TITLE
[#4] Post 테스트 코드 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -81,14 +81,14 @@ public class PostController {
 	}
 
 	@PutMapping("/{postId}")
-	public ResponseEntity<ApiResponse<PostResponse>> updatePost(
+	public ResponseEntity<ApiResponse<Void>> updatePost(
 		@PathVariable Long postId,
 		@AuthenticationPrincipal Long memberId,
 		@RequestBody PostRequest request
 	) {
-		PostResponse postResponse = postService.updatePost(postId, request, memberId);
-		ApiResponse<PostResponse> response = ApiResponse.success(postResponse);
-		URI location = URI.create("/posts/" + postId.toString());
+		Long updateId = postService.updatePost(postId, request, memberId);
+		ApiResponse<Void> response = ApiResponse.success();
+		URI location = URI.create("/posts/" + updateId);
 		return ResponseEntity.ok().location(location).body(response);
 	}
 

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
@@ -13,7 +13,7 @@ import com.clover.habbittracker.domain.post.entity.Post;
 public interface PostCustomRepository {
 	List<Post> findAllPostsSummary(Pageable pageable, Post.Category category);
 
-	Optional<Post> joinCommentAndLikeFindById(@Param("postId") Long postId);
+	Optional<Post> joinMemberAndCommentFindById(@Param("postId") Long postId);
 
 	Long updateViews(Long postId);
 

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
@@ -44,7 +44,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 	}
 
 	@Override
-	public Optional<Post> joinCommentAndLikeFindById(Long postId) {
+	public Optional<Post> joinMemberAndCommentFindById(Long postId) {
 		Post result = jpaQueryFactory.selectFrom(post)
 			.leftJoin(post.member, member)
 			.fetchJoin()

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostService.java
@@ -20,7 +20,7 @@ public interface PostService {
 
 	Page<PostResponse> getPostBy(PostSearchCondition postSearchCondition, Pageable pageable);
 
-	PostResponse updatePost(Long postId, PostRequest request, Long memberId);
+	Long updatePost(Long postId, PostRequest request, Long memberId);
 
 	void deletePost(Long postId, Long memberId);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -68,12 +68,12 @@ public class PostServiceImpl implements PostService {
 
 	@Override
 	@Transactional
-	public PostResponse updatePost(Long postId, PostRequest request, Long memberId) {
+	public Long updatePost(Long postId, PostRequest request, Long memberId) {
 		Post post = postRepository.joinMemberAndCommentFindById(postId)
 			.orElseThrow(() -> new PostNotFoundException(postId));
 		verifyPermissions(post.getMember(), memberId);
 		post.updatePost(request);
-		return postMapper.toPostResponse(post);
+		return post.getId();
 	}
 
 	@Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
       hibernate:
         format_sql: true
         globally_quoted_identifiers: true
-    dialect: com.clover.habbittracker.global.config.db.MySQLConfig.MySQLCustomDialect
+        dialect: com.clover.habbittracker.global.config.db.MySQLConfig$MySQLCustomDialect
 
   # redis
   redis:

--- a/src/test/java/com/clover/habbittracker/domain/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/mapper/PostMapperTest.java
@@ -1,0 +1,95 @@
+package com.clover.habbittracker.domain.post.mapper;
+
+import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.global.util.PostProvider.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.clover.habbittracker.domain.comment.dto.CommentResponse;
+import com.clover.habbittracker.domain.comment.mapper.CommentMapper;
+import com.clover.habbittracker.domain.comment.mapper.CommentMapperImpl;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
+import com.clover.habbittracker.domain.post.dto.PostResponse;
+import com.clover.habbittracker.domain.post.entity.Post;
+
+public class PostMapperTest {
+
+	private final PostMapper postMapper = new PostMapperImpl();
+
+	private Member testMember;
+
+	private Post testPost;
+
+	@BeforeEach
+	void setUp() {
+		testMember = createTestMember();
+		testPost = createTestPost(testMember);
+	}
+
+	@Test
+	@DisplayName("PostRequest 를 Post 로 매핑 시킬 수 있다.")
+	void toPostTest() {
+		//given
+		PostRequest postRequest = createPostRequest();
+		//when
+		Post post = postMapper.toPost(postRequest, testMember);
+		//then
+		assertAll(() -> {
+			assertThat(post.getTitle()).isEqualTo(postRequest.title());
+			assertThat(post.getContent()).isEqualTo(postRequest.content());
+			assertThat(post.getCategory()).isEqualTo(postRequest.category());
+		});
+	}
+
+	@Test
+	@DisplayName("Post 를 PostResponse 로 매핑 시킬 수 있다.")
+	void toPostResponseTest() {
+
+		//given & when
+		PostResponse postResponse = postMapper.toPostResponse(testPost);
+
+		//then
+		assertAll(() -> {
+			assertThat(testPost.getId()).isEqualTo(postResponse.id());
+			assertThat(testPost.getTitle()).isEqualTo(postResponse.title());
+			assertThat(testPost.getContent()).isEqualTo(postResponse.content());
+			assertThat(testPost.getCategory()).isEqualTo(postResponse.category());
+			assertThat(testPost.getViews()).isEqualTo(postResponse.views());
+			assertThat(testPost.getEmojis().size()).isEqualTo(postResponse.numOfEmojis());
+			assertThat(testPost.getComments().size()).isEqualTo(postResponse.numOfComments());
+		});
+
+	}
+
+	@Test
+	@DisplayName("Post 를 PostDetailResponse 로 매핑 시킬 수 있다.")
+	void toPostDetailResponseTest() {
+		//given
+		CommentMapper commentMapper = new CommentMapperImpl();
+		List<CommentResponse> comments = testPost.getComments()
+			.stream()
+			.map(commentMapper::toCommentResponse)
+			.toList();
+
+		//when
+		PostDetailResponse postDetailResponse = postMapper.toPostDetail(testPost);
+
+		//then
+		assertAll(() -> {
+			assertThat(testPost.getTitle()).isEqualTo(postDetailResponse.title());
+			assertThat(testPost.getContent()).isEqualTo(postDetailResponse.content());
+			assertThat(testPost.getCategory()).isEqualTo(postDetailResponse.category());
+			assertThat(testPost.getViews()).isEqualTo(postDetailResponse.views());
+			assertThat(testPost.getEmojis()).isEqualTo(postDetailResponse.emojis());
+			assertThat(comments).isEqualTo(postDetailResponse.comments());
+		});
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
@@ -1,0 +1,149 @@
+package com.clover.habbittracker.domain.post.repository;
+
+import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.global.util.PostProvider.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.clover.habbittracker.global.config.db.JpaConfig;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class PostRepositoryTest {
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Member testMember;
+
+	private Pageable pageable;
+
+	@BeforeEach
+	void setUp() {
+		testMember = memberRepository.save(createTestMember());
+		pageable = PageRequest.of(0, 15);
+	}
+
+	@Test
+	@DisplayName("사용자는 게시글을 등록할 수 있다.")
+	void savePostTest() {
+		//given
+		Post testPost = createTestPost(testMember);
+		//when
+		Post savePost = postRepository.save(testPost);
+		//then
+		assertThat(savePost).usingRecursiveComparison().isEqualTo(testPost);
+	}
+
+	@Test
+	@DisplayName("게시글을 페이징 처리하여 조회 할 수 있다.")
+	void findAllPostsSummary() {
+		//given
+		for (int i = 0; i < 50; i++) {
+			Post testPost = createTestPost(testMember);
+			postRepository.save(testPost);
+		}
+		//when
+		List<Post> postsSummary = postRepository.findAllPostsSummary(pageable, null);
+
+		//then
+		assertThat(postsSummary.size()).isEqualTo(15);
+	}
+
+	@Test
+	@DisplayName("게시글 Id 로 게시글의 등록자, 댓글을 모두 포함 하여 조회 할 수 있다.")
+	void joinCommentAndLikeFindById() {
+		//given
+		Post testPost = createTestPost(testMember);
+		Post savePost = postRepository.save(testPost);
+
+		//when
+		Optional<Post> findPost = postRepository.joinMemberAndCommentFindById(savePost.getId());
+
+		//then
+		assertThat(findPost).isPresent();
+		assertThat(findPost.get()).usingRecursiveComparison().isEqualTo(savePost);
+	}
+
+	@Test
+	@DisplayName("게시글의 카테고리 별 조회를 할 수 있다.")
+	void postCategoryFilterTest() {
+		//given
+		Post postDaily = createTestPost(testMember, Post.Category.DAILY);
+		Post postETC = createTestPost(testMember, Post.Category.ETC);
+		Post savePostDaily = postRepository.save(postDaily);
+		Post savePostETC = postRepository.save(postETC);
+
+		//when
+		List<Post> dailyPostsSummary = postRepository.findAllPostsSummary(pageable, Post.Category.DAILY);
+
+		//then
+		assertThat(dailyPostsSummary.size()).isEqualTo(1);
+		assertThat(dailyPostsSummary.get(0)).usingRecursiveComparison().isEqualTo(savePostDaily);
+	}
+
+	// TODO: 조회수 개선 이후 테스트 진행. 현재 정상적으로 테스트가 불가능.
+	// @Test
+	// @DisplayName("게시글의 조회수는 1씩 증가한다.")
+	// void updateViewTest() throws InterruptedException {
+	// 	//given
+	// 	int threadNum = 3;
+	// 	Post testPost = createTestPost(testMember);
+	// 	Post savedPost = postRepository.save(testPost);
+	//
+	// 	ExecutorService executorService = Executors.newFixedThreadPool(threadNum);
+	// 	CountDownLatch latch = new CountDownLatch(threadNum);
+	//
+	// 	//when
+	// 	for (int i = 0; i < threadNum; i++) {
+	// 		executorService.execute(() -> {
+	// 			postRepository.updateViews(savedPost.getId());
+	// 			latch.countDown();
+	// 		});
+	// 	}
+	// 	latch.await();
+	//
+	// 	//then
+	// 	assertThat(savedPost.getViews()).isEqualTo(1);
+	// }
+
+	@Test
+	void searchByPostTest() {
+		//given
+		Post build = Post.builder()
+			.title("title")
+			.content("content")
+			.category(Post.Category.DAILY)
+			.member(testMember)
+			.build();
+		Post save = postRepository.save(build);
+		PostSearchCondition searchCondition = new PostSearchCondition(save.getCategory(),
+			PostSearchCondition.SearchType.CONTENT, save.getContent());
+		//when
+		Page<Post> posts = postRepository.searchPostBy(searchCondition, pageable);
+
+		//then
+		assertThat(posts.getTotalElements()).isEqualTo(1);
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/service/PostServiceTest.java
@@ -1,0 +1,190 @@
+package com.clover.habbittracker.domain.post.service;
+
+import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.global.util.PostProvider.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.transaction.BeforeTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
+import com.clover.habbittracker.domain.post.dto.PostResponse;
+import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.clover.habbittracker.domain.post.repository.PostRepository;
+
+@SpringBootTest
+@Transactional
+public class PostServiceTest {
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private PostService postService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Member testMember;
+
+	private final Pageable pageable = PageRequest.of(0, 15);
+
+	@BeforeEach
+	public void setUp() {
+		Member member = createTestMember();
+		testMember = memberRepository.save(member);
+	}
+
+	@Test
+	@DisplayName("사용자의 아이디와 게시글 등록 요청을 받아 게시글을 등록 할 수 있다.")
+	void registerTest() {
+		//given
+		PostRequest request = createPostRequest();
+		//when
+		Long postId = postService.register(testMember.getId(), request);
+		//then
+		Optional<Post> savedPost = postRepository.findById(postId);
+		assertAll(() -> {
+			assertThat(savedPost).isPresent();
+			assertThat(savedPost.get().getTitle()).isEqualTo(request.title());
+			assertThat(savedPost.get().getContent()).isEqualTo(request.content());
+			assertThat(savedPost.get().getCategory()).isEqualTo(request.category());
+		});
+	}
+
+	@Test
+	@DisplayName("사용자의 아이디와 게시글 수정 요청을 받아 게시글을 수정 할 수 있다.")
+	void updatePostTest() {
+		//given
+		Post post = postRepository.save(createTestPost(testMember));
+		PostRequest updateRequest = createPostRequest();
+		//when
+		Long postId = postService.updatePost(post.getId(), updateRequest, testMember.getId());
+		//then
+		Optional<Post> updatedPost = postRepository.findById(postId);
+		assertAll(() -> {
+			assertThat(updatedPost).isPresent();
+			assertThat(updatedPost.get().getTitle()).isEqualTo(updateRequest.title());
+			assertThat(updatedPost.get().getContent()).isEqualTo(updateRequest.content());
+			assertThat(updatedPost.get().getCategory()).isEqualTo(updateRequest.category());
+		});
+	}
+
+	@Test
+	@DisplayName("게시글 아이디로 게시글의 상세내용을 조회 할 수 있다.")
+	void getPostTest() {
+		//given
+		Post post = postRepository.save(createTestPost(testMember));
+		//when
+		PostDetailResponse postDetail = postService.getPostBy(post.getId());
+		//then
+		assertAll(() -> {
+			assertThat(post.getTitle()).isEqualTo(postDetail.title());
+			assertThat(post.getContent()).isEqualTo(postDetail.content());
+			assertThat(post.getCategory()).isEqualTo(postDetail.category());
+			assertThat(post.getComments()).isNotNull();
+			assertThat(post.getEmojis()).isNotNull();
+		});
+	}
+
+	@Test
+	@DisplayName("게시글 아이디로 게시글을 삭제 할 수 있다.")
+	void deletePostTest() {
+		//given
+		Post post = postRepository.save(createTestPost(testMember));
+		//when
+		postService.deletePost(post.getId(), testMember.getId());
+		//then
+		Optional<Post> deletedPost = postRepository.findById(post.getId());
+		assertThat(deletedPost).isEmpty();
+	}
+
+	@Nested
+	@Sql(scripts = "/searchTest_after.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+	@DisplayName("검색은")
+	class searchBy {
+
+		private Post savedPost;
+
+		@BeforeTransaction
+		void setUp() {
+			Post post = createTestPost(testMember);
+			savedPost = postRepository.save(post);
+		}
+
+		@Test
+		@DisplayName("카테고리로 할수있다")
+		void categoryTest() {
+			//when
+			List<PostResponse> categoryFilterPost = postService.getPostAllBy(savedPost.getCategory(), pageable);
+			//then
+			assertAll(() -> {
+				assertThat(categoryFilterPost.size()).isEqualTo(1);
+				assertThat(categoryFilterPost.get(0).title()).isEqualTo(savedPost.getTitle());
+				assertThat(categoryFilterPost.get(0).content()).isEqualTo(savedPost.getContent());
+				assertThat(categoryFilterPost.get(0).category()).isEqualTo(savedPost.getCategory());
+			});
+
+		}
+
+		@Test
+		@DisplayName("제목으로 할수있다")
+		void titleTest() {
+			//given
+			PostSearchCondition condition = new PostSearchCondition(
+				Post.Category.ALL,
+				PostSearchCondition.SearchType.TITLE,
+				savedPost.getTitle());
+
+			//when
+			Page<PostResponse> titleFilterPost = postService.getPostBy(condition, pageable);
+			List<PostResponse> postList = titleFilterPost.getContent();
+			//then
+			assertAll(() -> {
+				assertThat(postList.size()).isEqualTo(1);
+				assertThat(postList.get(0).title()).isEqualTo(savedPost.getTitle());
+				assertThat(postList.get(0).content()).isEqualTo(savedPost.getContent());
+				assertThat(postList.get(0).category()).isEqualTo(savedPost.getCategory());
+			});
+		}
+
+		@Test
+		@DisplayName("본문으로 할수있다")
+		void contentTest() {
+			//given
+			PostSearchCondition condition = new PostSearchCondition(
+				Post.Category.ALL,
+				PostSearchCondition.SearchType.CONTENT,
+				savedPost.getContent());
+
+			//when
+			Page<PostResponse> titleFilterPost = postService.getPostBy(condition, pageable);
+			List<PostResponse> postList = titleFilterPost.getContent();
+			//then
+			assertAll(() -> {
+				assertThat(postList.size()).isEqualTo(1);
+				assertThat(postList.get(0).title()).isEqualTo(savedPost.getTitle());
+				assertThat(postList.get(0).content()).isEqualTo(savedPost.getContent());
+				assertThat(postList.get(0).category()).isEqualTo(savedPost.getCategory());
+			});
+		}
+	}
+}

--- a/src/test/java/com/clover/habbittracker/global/util/PostProvider.java
+++ b/src/test/java/com/clover/habbittracker/global/util/PostProvider.java
@@ -1,12 +1,15 @@
 package com.clover.habbittracker.global.util;
 
 import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.post.dto.PostRequest;
 import com.clover.habbittracker.domain.post.entity.Post;
 
 public class PostProvider {
 
 	private static final String TITLE = "testTitle";
 	private static final String CONTENT = "testContent";
+	private static final String REQUEST_TITLE = "requestTitle";
+	private static final String REQUEST_CONTENT = "requestContent";
 	private static final Post.Category CATEGORY = Post.Category.DAILY;
 
 	public static Post createTestPost(Member member) {
@@ -25,5 +28,9 @@ public class PostProvider {
 			.category(category)
 			.member(member)
 			.build();
+	}
+
+	public static PostRequest createPostRequest() {
+		return new PostRequest(REQUEST_TITLE, REQUEST_CONTENT, CATEGORY);
 	}
 }

--- a/src/test/java/com/clover/habbittracker/global/util/PostProvider.java
+++ b/src/test/java/com/clover/habbittracker/global/util/PostProvider.java
@@ -17,4 +17,13 @@ public class PostProvider {
 			.member(member)
 			.build();
 	}
+
+	public static Post createTestPost(Member member, Post.Category category) {
+		return Post.builder()
+			.title(TITLE)
+			.content(CONTENT)
+			.category(category)
+			.member(member)
+			.build();
+	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,7 +15,11 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: none
-    dialect: com.clover.habbittracker.global.config.db.MySQLConfig.MySQLCustomDialect
+
+    properties:
+      hibernate:
+        dialect: com.clover.habbittracker.global.config.db.MySQLConfig$MySQLCustomDialect
+        format_sql: true
   #    defer-datasource-initialization: true
   config:
     import: application-token.yml, application-security.yml

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,3 +27,12 @@ spring:
   redis:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
+
+logging:
+  level:
+    org:
+      hibernate:
+        engine:
+          transaction:
+            internal:
+              TransactionImpl: DEBUG

--- a/src/test/resources/searchTest_after.sql
+++ b/src/test/resources/searchTest_after.sql
@@ -1,0 +1,5 @@
+DELETE
+FROM post;
+DELETE
+FROM member;
+commit


### PR DESCRIPTION
# 작업 사항
- #4 


- [feat(Test) : PostServiceTest 추가](https://github.com/Clover-Habiters/backend/commit/c5387d13ee40e3ee968441a15f6bd401230e2791) 
    - PostServiceTest 를 추가하였습니다.
    - 특이 사항으로는 Post 검색 조회 시 CustomMySQLDialect 를 활용하여 FullText Search 를 진행합니다.
    - 하지만,@transaction 설정이 있다면 DB로 commit 바로 하지 않고, 1차 캐시로 데이터 조회와 저장 테스트합니다.
    - 검색 테스트 시 실제 DB로 바로 query 를 보내지만 위와 같은 이유로 실제로 데이터가 존재하지 않기에 검색 결과가 정상적으로 나오지 않았습니다.
    - 따라서 테스트를 실행 하기전 @BeforeTransaction 을 진행하여 Post 를 등록 후 테스트를 진행하며 테스트가 끝난 후에 데이터를 삭제하는 SQL 스크립트를 실행하도록 하였습니다.

- [feat(Test) : PostMapperTest 추가](https://github.com/Clover-Habiters/backend/commit/e1e4e98673aed83f233a31fdf9a9f609ddb338d7) 
    - PostMapperTest 테스트 코드를 추가하였습니다.
    - CommentMapperTest 와 마찬가지로 빈에서 조회 하지 않고, 직접 구현제를 사용하는 방식으로 테스트를 진행하였습니다.
   
### 테스트는 추가로 업데이트 할 예정입니다~!

# 이외의 작업
- [config : application.yml](https://github.com/Clover-Habiters/backend/commit/e2989d3a5c52df576a2b606a84b10fe585cd807b)
    - MySQL dialect 설정을 변경하였습니다.
    - "MySQLConfig$MySQLCustomDialect" 로 수정하였습니다.
    -  Transaction 실행과 끝을 확인 할 수 있는 로그를 추가하였습니다.
    - 테스트 시 트랜잭션의 시작과 끝을 알아보고자 추가하였습니다.
- [chore : PostRepository](https://github.com/Clover-Habiters/backend/commit/45ee3bdc488f9410c2b402c648bd26e207c2a9fb)
    - joinCommentAndLikeFindById 의 메서드 명을 joinMemberAndCommentFindById 로 변경하였습니다.
    - Like 는 join 대상이 아니며, 멤버와 댓글을 join 하여 가져오는 메서드로 이름을 정확하게 수정하였습니다.
    - PostRequest 정보 또한 PostProvider 가 제공해줄수 있도록 추가하였습니다.
    - PostRequest 에 내용이 Post 과 같다면 혼동이 올수있기에 PostRequest 에 제목과 내용을 추가하였습니다.
- [chore : PostRepository 메서드 이름 변경](https://github.com/Clover-Habiters/backend/commit/45ee3bdc488f9410c2b402c648bd26e207c2a9fb) 
    - joinCommentAndLikeFindById 의 메서드 명을 joinMemberAndCommentFindById 로 변경하였습니다.
    - Like 는 join 대상이 아니며, 멤버와 댓글을 join 하여 가져오는 메서드로 이름을 정확하게 수정하였습니다.
- [chore : PostService 단건 조회 메서드 변경](https://github.com/Clover-Habiters/backend/commit/55987f33819e8bbde3e960903810016f903d25e4) 
    - Post 를 단건으로 조회 시 findById 보다 join 해서 가져오도록 수정하였습니다.
    - 이유는 N + 1 문제가 발생 할 수 있으므로, Post 단건으로 조회시에는 반드시 join 으로 한번에 가져오도록 하기 위함입니다.
- [chore : PostUpdate 변경](https://github.com/Clover-Habiters/backend/commit/1223f1966a10f26367dab7bc777ed71a313ed75f) 
    - PostUpdate 시 기존에 PostResponse 를 반환하였지만, 수정 내용을 보냄과 동시에 location 까지 보내는것은 불필요하다 생각합니다.
    - 따라서, Post 생성시와 마찬가지로 location 정보만 보내는 것으로 변경하였습니다.