### PR TITLE
[#5] Emoji 리팩터링 및 테스트 코드 추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
@@ -1,11 +1,17 @@
 package com.clover.habbittracker.domain.comment.dto;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.*;
+
 import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record CommentResponse(
 	Long id,
 	String content,
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDateTime createDate,
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDateTime updateDate
 ) {
 

--- a/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryResponse.java
@@ -1,8 +1,11 @@
 package com.clover.habbittracker.domain.diary.dto;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.*;
+
 import java.time.LocalDateTime;
 
 import com.clover.habbittracker.domain.diary.entity.Diary;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +15,9 @@ import lombok.Getter;
 public class DiaryResponse {
 	private Long id;
 	private String content;
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private LocalDateTime createDate;
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private LocalDateTime endUpdateDate;
 
 	public static DiaryResponse from(Diary diary) {

--- a/src/main/java/com/clover/habbittracker/domain/emoji/api/EmojiController.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/api/EmojiController.java
@@ -1,13 +1,20 @@
 package com.clover.habbittracker.domain.emoji.api;
 
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.clover.habbittracker.domain.emoji.dto.EmojiResponse;
 import com.clover.habbittracker.domain.emoji.entity.Emoji;
 import com.clover.habbittracker.domain.emoji.service.EmojiService;
 
@@ -15,34 +22,41 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/posts/{postId}")
+@RequestMapping("/{domain}/{domainId}/emojis")
 public class EmojiController {
 
 	private final EmojiService emojiService;
 
-	@PostMapping("/emojis")
-	public void clickEmojiOnPost(
-		@AuthenticationPrincipal Long memberId,
-		@PathVariable Long postId,
-		@RequestParam Emoji.Type type
+	@GetMapping
+	public ResponseEntity<List<EmojiResponse>> getAllEmojis(
+		@PathVariable Emoji.Domain domain,
+		@PathVariable Long domainId
 	) {
-		emojiService.clickOnPost(memberId, postId, type);
+		List<EmojiResponse> emojis = emojiService.getAllEmojisInDomain(domain, domainId);
+
+		return ResponseEntity.ok().body(emojis);
 	}
 
-	@PostMapping("/comments/{commentId}/emojis")
-	public void clickEmojiOnComment(
+	@PutMapping
+	public ResponseEntity<EmojiResponse> saveEmoji(
 		@AuthenticationPrincipal Long memberId,
-		@PathVariable Long commentId,
-		@RequestParam Emoji.Type type
+		@PathVariable Emoji.Domain domain,
+		@PathVariable Long domainId,
+		@RequestParam(name = "type") Emoji.Type emojiType
 	) {
-		emojiService.clickOnComment(memberId, commentId, type);
+		EmojiResponse emoji = emojiService.save(emojiType, memberId, domain, domainId);
+
+		return ResponseEntity.ok().body(emoji);
 	}
 
-	@GetMapping("/emojis")
-	public int getAmountEmojisInPost(
-		@PathVariable Long postId
+	@DeleteMapping
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteEmoji( // soft delete
+		@AuthenticationPrincipal Long memberId,
+		@PathVariable Emoji.Domain domain,
+		@PathVariable Long domainId
 	) {
-		return emojiService.getAmountInPost(postId);
+		emojiService.delete(memberId, domain, domainId);
 	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/emoji/dto/EmojiResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/dto/EmojiResponse.java
@@ -1,0 +1,9 @@
+package com.clover.habbittracker.domain.emoji.dto;
+
+public record EmojiResponse(
+	String emojiType,
+	Long memberId,
+	String domain,
+	Long domainId
+) {
+}

--- a/src/main/java/com/clover/habbittracker/domain/emoji/entity/Emoji.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/entity/Emoji.java
@@ -4,8 +4,11 @@ import static lombok.AccessLevel.*;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+import org.springframework.core.convert.converter.Converter;
 
 import com.clover.habbittracker.global.base.entity.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +16,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,27 +24,17 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "emoji")
+@Table(name = "emoji",
+	indexes = {
+		@Index(name = "idx_emoji_member_id", columnList = "memberId"),
+		@Index(name = "idx_emoji_domain", columnList = "domain,domainId"),
+		@Index(name = "idx_emoji_unique", columnList = "memberId, domain,domainId", unique = true)
+	}
+)
 @NoArgsConstructor(access = PROTECTED)
 @Where(clause = "deleted = false")
 @SQLDelete(sql = "UPDATE emoji set deleted = true where id=?")
 public class Emoji extends BaseEntity {
-
-	public enum Type {
-		SMILE, ANGRY, SAD, SURPRISED, NONE
-	}
-
-	public enum Domain {
-		COMMENT, POST;
-
-		public boolean isPost() {
-			return this == POST;
-		}
-
-		public boolean isComment() {
-			return this == COMMENT;
-		}
-	}
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,19 +51,60 @@ public class Emoji extends BaseEntity {
 	private Long domainId;
 
 	@Builder
-	public Emoji(Domain domain, Type type, Long memberId, Long domainId) {
-		this.domain = domain;
+	public Emoji(Type type, Long memberId, Domain domain, Long domainId) { // 무엇을 누가 어디에
 		this.type = type;
 		this.memberId = memberId;
+		this.domain = domain;
 		this.domainId = domainId;
 	}
 
-	public void updateStatus(Type type) {
+	public Emoji updateStatus(Type type) {
 		this.type = type;
+		return this;
 	}
 
-	public boolean isSameType(Type type) {
-		return this.type == type;
+	public enum Type {
+		SMILE, ANGRY, SAD, SURPRISED, HEART, NONE;
+
+		@JsonCreator
+		public static Type fromJson(@JsonProperty("type") String name) {
+			return valueOf(name.toUpperCase());
+		}
+
+		public boolean isSame(Type type) {
+			return this == type;
+		}
+
+		public static class StringToEmojiTypeConverter
+			implements Converter<String, Type> {
+
+			@Override
+			public Type convert(String source) {
+				return Type.valueOf(source.toUpperCase());
+			}
+		}
+	}
+
+	public enum Domain {
+		COMMENT, POST;
+
+		@JsonCreator
+		public static Domain fromJson(@JsonProperty("domain") String name) {
+			return valueOf(name.toUpperCase());
+		}
+
+		public boolean isSame(Domain domain) {
+			return this == domain;
+		}
+
+		public static class StringToEmojiDomainConverter
+			implements Converter<String, Domain> {
+
+			@Override
+			public Domain convert(String source) {
+				return Domain.valueOf(source.toUpperCase());
+			}
+		}
 	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/emoji/mapper/EmojiMapper.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/mapper/EmojiMapper.java
@@ -1,0 +1,28 @@
+package com.clover.habbittracker.domain.emoji.mapper;
+
+import static org.mapstruct.ReportingPolicy.*;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import com.clover.habbittracker.domain.emoji.dto.EmojiResponse;
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = IGNORE)
+public interface EmojiMapper {
+
+	@Mapping(target = "emojiType", source = "emoji", qualifiedByName = "emojiTypeMethod")
+	@Mapping(target = "domain", source = "emoji", qualifiedByName = "emojiDomainMethod")
+	EmojiResponse toEmojiResponse(Emoji emoji);
+
+	@Named("emojiTypeMethod")
+	default String mapEmojiType(Emoji emoji) {
+		return emoji.getType().name();
+	}
+
+	@Named("emojiDomainMethod")
+	default String mapEmojiDomain(Emoji emoji) {
+		return emoji.getDomain().name();
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/emoji/repository/EmojiCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/repository/EmojiCustomRepository.java
@@ -1,5 +1,16 @@
 package com.clover.habbittracker.domain.emoji.repository;
 
+import java.util.List;
+import java.util.Optional;
+
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
+
 public interface EmojiCustomRepository {
-	int countByPostId(Long postId);
+
+	List<Emoji> findAllInDomain(Emoji.Domain domain, Long domainId);
+
+	Optional<Emoji> findByUniqueKey(Long memberId, Emoji.Domain domain, Long domainId);
+
+	int countByDomain(Emoji.Domain domain, Long domainId);
+
 }

--- a/src/main/java/com/clover/habbittracker/domain/emoji/repository/EmojiCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/repository/EmojiCustomRepositoryImpl.java
@@ -2,8 +2,12 @@ package com.clover.habbittracker.domain.emoji.repository;
 
 import static com.clover.habbittracker.domain.emoji.entity.QEmoji.*;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -15,9 +19,34 @@ public class EmojiCustomRepositoryImpl implements EmojiCustomRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public int countByPostId(Long postId) {
-		return jpaQueryFactory.selectFrom(emoji)
-			.where(emoji.domainId.eq(postId))
+	public List<Emoji> findAllInDomain(Emoji.Domain domain, Long domainId) {
+		return jpaQueryFactory
+			.selectFrom(emoji)
+			.where(emoji.domain.eq(domain)
+				.and(emoji.domainId.eq(domainId)))
+			.fetch();
+	}
+
+	@Override
+	public Optional<Emoji> findByUniqueKey(Long memberId, Emoji.Domain domain, Long domainId) {
+
+		Emoji result = jpaQueryFactory
+			.selectFrom(emoji)
+			.where(
+				emoji.memberId.eq(memberId)
+					.and(emoji.domain.eq(domain))
+					.and(emoji.domainId.eq(domainId)))
+			.fetchOne();
+
+		return Optional.ofNullable(result);
+	}
+
+	@Override
+	public int countByDomain(Emoji.Domain domain, Long domainId) {
+		return jpaQueryFactory
+			.selectFrom(emoji)
+			.where(emoji.domain.eq(domain)
+				.and(emoji.domainId.eq(domainId)))
 			.fetch().size();
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/emoji/repository/EmojiRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/repository/EmojiRepository.java
@@ -1,33 +1,10 @@
 package com.clover.habbittracker.domain.emoji.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.clover.habbittracker.domain.emoji.entity.Emoji;
 
 public interface EmojiRepository extends JpaRepository<Emoji, Long>, EmojiCustomRepository {
 
-	@Query(value = "select * from member "
-	               + "where memberId = :memberId "
-	               + "AND domainId = :postId "
-	               + "AND domain = 'POST'",
-		nativeQuery = true)
-	Optional<Emoji> findByMemberIdAndPostId(
-		@Param("memberId") Long memberId,
-		@Param("postId") Long postId
-	);
-
-	@Query(value = "select * from member "
-	               + "where memberId = :memberId "
-	               + "AND domainId = :commentId "
-	               + "AND domain = 'COMMENT'",
-		nativeQuery = true)
-	Optional<Emoji> findByMemberIdAndCommentId(
-		@Param("memberId") Long memberId,
-		@Param("commentId") Long commentId
-	);
 }
 

--- a/src/main/java/com/clover/habbittracker/domain/emoji/service/EmojiService.java
+++ b/src/main/java/com/clover/habbittracker/domain/emoji/service/EmojiService.java
@@ -1,78 +1,61 @@
 package com.clover.habbittracker.domain.emoji.service;
 
-import static com.clover.habbittracker.domain.emoji.entity.Emoji.Domain.*;
-
-import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.clover.habbittracker.domain.emoji.dto.EmojiResponse;
 import com.clover.habbittracker.domain.emoji.entity.Emoji;
+import com.clover.habbittracker.domain.emoji.mapper.EmojiMapper;
 import com.clover.habbittracker.domain.emoji.repository.EmojiRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class EmojiService {
 
 	private final EmojiRepository emojiRepository;
+	private final EmojiMapper emojiMapper;
 
-	// 검증 로직을 제외해봤음!
-	@Transactional
-	public void clickOnPost(Long memberId, Long postId, Emoji.Type type) {
-
-		Optional<Emoji> emoji = emojiRepository.findByMemberIdAndPostId(memberId, postId);
-
-		emoji.ifPresentOrElse(
-			updateOrDelete(type),
-			() -> {
-
-				Emoji newEmoji = Emoji.builder()
-					.type(type)
-					.domain(Emoji.Domain.POST)
-					.domainId(postId)
-					.memberId(memberId)
-					.build();
-
-				emojiRepository.save(newEmoji);
-			}
-		);
+	public List<EmojiResponse> getAllEmojisInDomain(Emoji.Domain domain, Long domainId) {
+		return emojiRepository.findAllInDomain(domain, domainId)
+			.stream()
+			.map(emojiMapper::toEmojiResponse)
+			.toList();
 	}
 
 	@Transactional
-	public void clickOnComment(Long memberId, Long commentId, Emoji.Type type) {
+	public EmojiResponse save(Emoji.Type emojiType, Long memberId, Emoji.Domain domain, Long domainId) {
 
-		Optional<Emoji> emoji = emojiRepository.findByMemberIdAndCommentId(memberId, commentId);
+		// 존재하면 상태 변경, 존재하지 않는 경우 생성 -> Insert or Update
+		// 그냥 save하고 다른 점이 있는지 확인 필요
+		Emoji savedEmoji = emojiRepository.findByUniqueKey(memberId, domain, domainId)
+			.map(e -> e.updateStatus(emojiType))
+			.orElseGet(
+				() -> emojiRepository.save(
+					Emoji.builder()
+						.type(emojiType)
+						.domain(domain)
+						.domainId(domainId)
+						.memberId(memberId)
+						.build()
+				)
+			);
 
-		emoji.ifPresentOrElse(
-			updateOrDelete(type),
-			() -> {
-				Emoji newEmoji = Emoji.builder()
-					.type(type)
-					.domain(COMMENT)
-					.domainId(commentId)
-					.memberId(memberId)
-					.build();
-
-				emojiRepository.save(newEmoji);
-			}
-		);
+		return emojiMapper.toEmojiResponse(savedEmoji);
 	}
 
-	public int getAmountInPost(Long postId) {
-		return emojiRepository.countByPostId(postId);
-	}
-
-	private Consumer<Emoji> updateOrDelete(Emoji.Type type) {
-		return e -> {
-			if (e.isSameType(type)) {
-				e.updateStatus(Emoji.Type.NONE); // softdelete
-				return;
-			}
-			e.updateStatus(type);
-		};
+	@Transactional
+	public void delete(Long memberId, Emoji.Domain domain, Long domainId) {
+		// 존재하는 경우에만 동작 없으면 로깅
+		emojiRepository.findByUniqueKey(memberId, domain, domainId)
+			.ifPresentOrElse(emojiRepository::delete,
+				() -> log.warn("해당 이모지가 존재하지 않습니다.{},{},{}", memberId, domain, domainId)
+			);
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitResponse.java
@@ -1,8 +1,11 @@
 package com.clover.habbittracker.domain.habit.dto;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.*;
+
 import java.time.LocalDateTime;
 
 import com.clover.habbittracker.domain.habit.entity.Habit;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +15,7 @@ import lombok.Getter;
 public class HabitResponse {
 	private Long id;
 	private String content;
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private LocalDateTime createDate;
 
 	public static HabitResponse from(Habit habit) {

--- a/src/main/java/com/clover/habbittracker/domain/habit/dto/MyHabitResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/dto/MyHabitResponse.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import com.clover.habbittracker.domain.habit.entity.Habit;
 import com.clover.habbittracker.domain.habitcheck.dto.HabitCheckResponse;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,7 @@ public class MyHabitResponse {
 	private Long id;
 	private String content;
 	private List<HabitCheckResponse> habitChecks;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private LocalDateTime createDate;
 
 	public static MyHabitResponse from(Habit habit, Map<String, LocalDateTime> dateMap) {

--- a/src/main/java/com/clover/habbittracker/domain/habitcheck/dto/HabitCheckResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/habitcheck/dto/HabitCheckResponse.java
@@ -1,9 +1,12 @@
 package com.clover.habbittracker.domain.habitcheck.dto;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.clover.habbittracker.domain.habitcheck.entity.HabitCheck;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +17,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class HabitCheckResponse {
 	private Long id;
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private LocalDateTime updatedAt;
 
 	public static List<HabitCheckResponse> from(List<HabitCheck> habitChecks) {

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
@@ -1,11 +1,14 @@
 package com.clover.habbittracker.domain.post.dto;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.clover.habbittracker.domain.comment.dto.CommentResponse;
 import com.clover.habbittracker.domain.emoji.entity.Emoji;
 import com.clover.habbittracker.domain.post.entity.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record PostDetailResponse(
 	String title,
@@ -14,7 +17,9 @@ public record PostDetailResponse(
 	Long views,
 	List<CommentResponse> comments,
 	List<Emoji> emojis,
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDateTime createDate,
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDateTime updateDate
 ) {
 

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
@@ -1,8 +1,11 @@
 package com.clover.habbittracker.domain.post.dto;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.*;
+
 import java.time.LocalDateTime;
 
 import com.clover.habbittracker.domain.post.entity.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record PostResponse(
 	Long id,
@@ -12,6 +15,7 @@ public record PostResponse(
 	Long views,
 	Integer numOfComments,
 	Integer numOfEmojis,
+	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDateTime createDate
 ) {
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -58,6 +58,7 @@ public class Post extends BaseEntity {
 	@ManyToOne
 	@JoinColumn(name = "memberId")
 	private Member member;
+
 	@Builder
 	public Post(String title, String content, Category category, Member member) {
 		this.title = title;
@@ -74,6 +75,6 @@ public class Post extends BaseEntity {
 	}
 
 	public enum Category {
-		ALL, STUDY, EXERCISE, HEALTH, DAILY, ETC
+		ALL, NOTICE, STUDY, EXERCISE, HEALTH, DAILY, ETC
 	}
 }

--- a/src/main/java/com/clover/habbittracker/global/config/web/WebConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/config/web/WebConfig.java
@@ -1,28 +1,33 @@
 package com.clover.habbittracker.global.config.web;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@Configuration
-public class WebConfig {
-	@Bean
-	WebMvcConfigurer webMvcConfigurer() {
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
 
-		return new WebMvcConfigurer() {
-			public void addCorsMappings(CorsRegistry registry) {
-				registry.addMapping("/**")
-					.allowedOrigins("*")
-					.allowedMethods(
-						HttpMethod.GET.name(),
-						HttpMethod.POST.name(),
-						HttpMethod.DELETE.name(),
-						HttpMethod.PUT.name()
-					);
-			}
-		};
+@EnableWebMvc
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addFormatters(FormatterRegistry registry) {
+		registry.addConverter(new Emoji.Domain.StringToEmojiDomainConverter());
+		registry.addConverter(new Emoji.Type.StringToEmojiTypeConverter());
 	}
 
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("*")
+			.allowedMethods(
+				HttpMethod.GET.name(),
+				HttpMethod.POST.name(),
+				HttpMethod.DELETE.name(),
+				HttpMethod.PUT.name()
+			);
+	}
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -97,19 +97,22 @@ create table emoji
     domain       varchar(30) not null,
     type         varchar(30) not null,
     member_id    bigint      not null,
-    domain_id    bigint      null,
+    domain_id    bigint      not null,
     created_date datetime(6) not null default CURRENT_TIMESTAMP(6),
     updated_date datetime(6) not null default CURRENT_TIMESTAMP(6),
-    deleted      boolean     not null default false
+    deleted      boolean     not null default false,
+
+    unique index idx_emoji_unique (domain, domain_id, member_id),
+    index idx_emoji_domain (domain, domain_id),
+    index idx_emoji_member_id (member_id)
 );
 
 create table bookmark
 (
     id           bigint auto_increment primary key,
-    title        varchar(255) null,
-    description  varchar(500) null,
-    post_id      bigint       null,
-    member_id    bigint       null,
+    title        varchar(255) not null,
+    description  varchar(500) not null,
+    member_id    bigint       not null,
     created_date datetime(6)  not null default CURRENT_TIMESTAMP(6),
     updated_date datetime(6)  not null default CURRENT_TIMESTAMP(6),
     deleted      boolean      not null default false
@@ -117,6 +120,6 @@ create table bookmark
 
 create table bookmark_folder
 (
-    bookmark_id bigint null,
+    bookmark_id bigint not null,
     posts_id    bigint null
 );

--- a/src/test/java/com/clover/habbittracker/HabitTrackerApplicationTests.java
+++ b/src/test/java/com/clover/habbittracker/HabitTrackerApplicationTests.java
@@ -1,5 +1,6 @@
 package com.clover.habbittracker;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -7,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 class HabitTrackerApplicationTests {
 
 	@Test
+	@DisplayName("스프링 부트 어플리케이션 실행")
 	void contextLoads() {
 	}
 

--- a/src/test/java/com/clover/habbittracker/base/ControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/base/ControllerTest.java
@@ -1,0 +1,48 @@
+package com.clover.habbittracker.base;
+
+import static com.clover.habbittracker.util.MemberProvider.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.global.security.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "api.habiters.store")
+public abstract class ControllerTest {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@Autowired
+	protected JwtProvider jwtProvider;
+
+	@Autowired
+	protected MemberRepository memberRepository;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	protected Member savedMember;
+
+	protected String accessToken;
+
+	@BeforeEach
+	void setUpBase() {
+		Member member = createTestMember();
+		savedMember = memberRepository.save(member);
+		accessToken = jwtProvider.createAccessJwt(savedMember.getId());
+		System.out.println("Base Setting Complete");
+	}
+}

--- a/src/test/java/com/clover/habbittracker/base/RepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/base/RepositoryTest.java
@@ -1,0 +1,31 @@
+package com.clover.habbittracker.base;
+
+import static com.clover.habbittracker.util.MemberProvider.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.global.config.db.JpaConfig;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class RepositoryTest {
+
+	@Autowired
+	protected MemberRepository memberRepository;
+
+	protected Member savedMember;
+
+	@BeforeEach
+	void setUpBase() {
+		Member member = createTestMember();
+		savedMember = memberRepository.save(member);
+		System.out.println("Base Setting Complete");
+	}
+}

--- a/src/test/java/com/clover/habbittracker/base/ServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/base/ServiceTest.java
@@ -1,0 +1,28 @@
+package com.clover.habbittracker.base;
+
+import static com.clover.habbittracker.util.MemberProvider.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.member.repository.MemberRepository;
+
+@SpringBootTest
+@Transactional
+public abstract class ServiceTest {
+
+	@Autowired
+	protected MemberRepository memberRepository;
+
+	protected Member savedMember;
+
+	@BeforeEach
+	void setUpBase() {
+		Member member = createTestMember();
+		savedMember = memberRepository.save(member);
+		System.out.println("Base Setting Complete");
+	}
+}

--- a/src/test/java/com/clover/habbittracker/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/clover/habbittracker/config/EmbeddedRedisConfig.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.global.config;
+package com.clover.habbittracker.config;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/test/java/com/clover/habbittracker/domain/bookmark/api/BookmarkControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/bookmark/api/BookmarkControllerTest.java
@@ -1,8 +1,8 @@
 package com.clover.habbittracker.domain.bookmark.api;
 
-import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.ApiDocumentUtils.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
@@ -71,7 +71,6 @@ class BookmarkControllerTest {
 		savedMember = memberRepository.save(member);
 
 		accessToken = jwtProvider.createAccessJwt(savedMember.getId());
-
 
 		savedPost = postRepository.save(createTestPost(savedMember));
 

--- a/src/test/java/com/clover/habbittracker/domain/bookmark/entity/BookmarkTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/bookmark/entity/BookmarkTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.bookmark.entity;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.stream.Stream;
@@ -17,7 +17,7 @@ class BookmarkTest {
 
 	private static final String TITLE = "테스트 제목";
 	private static final String DESCRIPTION = "테스트 설명";
-	private static final String SIZE_500_STRING_DUMMY = "0" + "1234567890" .repeat(50);
+	private static final String SIZE_500_STRING_DUMMY = "0" + "1234567890".repeat(50);
 
 	private static Stream<Arguments> provideStringDummy() {
 		return Stream.of(

--- a/src/test/java/com/clover/habbittracker/domain/bookmark/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/bookmark/repository/BookmarkRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.bookmark.repository;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;

--- a/src/test/java/com/clover/habbittracker/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/bookmark/service/BookmarkServiceTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.bookmark.service;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;

--- a/src/test/java/com/clover/habbittracker/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/api/CommentControllerTest.java
@@ -1,8 +1,8 @@
 package com.clover.habbittracker.domain.comment.api;
 
-import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.ApiDocumentUtils.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
@@ -54,7 +54,6 @@ public class CommentControllerTest {
 	private String accessJwt;
 
 	private Post savePost;
-
 
 	@BeforeEach
 	void setUp() {
@@ -119,7 +118,7 @@ public class CommentControllerTest {
 		//when then
 		mockMvc.perform(
 				RestDocumentationRequestBuilders
-					.put("/posts/{postId}/comment/{commentId}",savePost.getId(), savedComment.getId())
+					.put("/posts/{postId}/comment/{commentId}", savePost.getId(), savedComment.getId())
 					.header("Authorization", "Bearer " + accessJwt)
 					.contentType(APPLICATION_JSON)
 					.content(request))

--- a/src/test/java/com/clover/habbittracker/domain/comment/mapper/CommentMapperTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/mapper/CommentMapperTest.java
@@ -12,8 +12,8 @@ import com.clover.habbittracker.domain.comment.dto.CommentResponse;
 import com.clover.habbittracker.domain.comment.entity.Comment;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.post.entity.Post;
-import com.clover.habbittracker.global.util.MemberProvider;
-import com.clover.habbittracker.global.util.PostProvider;
+import com.clover.habbittracker.util.MemberProvider;
+import com.clover.habbittracker.util.PostProvider;
 
 public class CommentMapperTest {
 

--- a/src/test/java/com/clover/habbittracker/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/repository/CommentRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.comment.repository;
 
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
@@ -20,7 +20,7 @@ import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.repository.PostRepository;
 import com.clover.habbittracker.global.config.db.JpaConfig;
-import com.clover.habbittracker.global.util.MemberProvider;
+import com.clover.habbittracker.util.MemberProvider;
 
 @DataJpaTest
 @Import(JpaConfig.class)

--- a/src/test/java/com/clover/habbittracker/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/service/CommentServiceTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.comment.service;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/api/DiaryControllerTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.diary.api;
 
-import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.ApiDocumentUtils.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.hamcrest.core.Is.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
@@ -199,7 +199,7 @@ public class DiaryControllerTest {
 		Long id = saveDiary.getId();
 		//when then
 		mockMvc.perform(
-				RestDocumentationRequestBuilders.delete("/diaries/{diaryId}" , id)
+				RestDocumentationRequestBuilders.delete("/diaries/{diaryId}", id)
 					.header("Authorization", "Bearer " + accessJwt))
 			.andExpect(status().isNoContent())
 			.andDo(document("diary-delete",

--- a/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.diary.repository;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;

--- a/src/test/java/com/clover/habbittracker/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/service/DiaryServiceTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.diary.service;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/clover/habbittracker/domain/emoji/api/EmojiControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/emoji/api/EmojiControllerTest.java
@@ -1,0 +1,229 @@
+package com.clover.habbittracker.domain.emoji.api;
+
+import static com.clover.habbittracker.domain.emoji.entity.Emoji.*;
+import static com.clover.habbittracker.util.ApiDocumentUtils.*;
+import static com.clover.habbittracker.util.CommentProvider.*;
+import static com.clover.habbittracker.util.EmojiProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.clover.habbittracker.base.ControllerTest;
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.comment.repository.CommentRepository;
+import com.clover.habbittracker.domain.emoji.repository.EmojiRepository;
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.clover.habbittracker.domain.post.repository.PostRepository;
+
+@DisplayName("Emoji API 테스트")
+class EmojiControllerTest extends ControllerTest {
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
+	private EmojiRepository emojiRepository;
+
+	private Post savedPostExistEmoji;
+
+	private Post savedPostNotExistEmoji;
+
+	private Comment savedCommentExistEmoji;
+
+	private Comment savedCommentNotExistEmoji;
+
+	@BeforeEach
+	void setUpDomain() {
+		// Post
+		savedPostExistEmoji = postRepository.save(createTestPost(savedMember));
+		emojiRepository.save(createTestEmojiInPost(savedMember, savedPostExistEmoji));
+		savedPostNotExistEmoji = postRepository.save(createTestPost(savedMember));
+		// Comment
+		savedCommentExistEmoji = commentRepository.save(createTestComment(savedMember, savedPostExistEmoji));
+		emojiRepository.save(createTestEmojiInComment(savedMember, savedCommentExistEmoji));
+		savedCommentNotExistEmoji = commentRepository.save(createTestComment(savedMember, savedPostNotExistEmoji));
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[200 성공] 이모지 저장(생성)")
+	void saveEmojiIn(Domain domain) throws Exception {
+		//given
+		Long domainId = getNotSavedEmojiDomainId(domain);
+		Type type = Type.SMILE;
+		//when then
+		mockMvc.perform(
+				put("/{domain}/{domainId}/emojis", domain.name().toLowerCase(), domainId)
+					.header("Authorization", "Bearer " + accessToken)
+					.queryParam("type", type.name())
+					.contentType(APPLICATION_JSON)
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.emojiType").value(type.name()))
+			.andExpect(jsonPath("$.memberId").value(savedMember.getId()))
+			.andExpect(jsonPath("$.domain").value(domain.name()))
+			.andExpect(jsonPath("$.domainId").value(domainId))
+			.andDo(print())
+			.andDo(document("emoji save(Insert or Update)",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("domain").description("이모지를 남기려는 도메인(ex. 게시글, 댓글)"),
+					parameterWithName("domainId").description("이모지를 남기려는 도메인의 아이디")
+				),
+				queryParameters(
+					parameterWithName("type").description("이모지 타입(ex. SMILE, SAD..)") // TODO: Enum 타입 문서화 추가
+				),
+				responseFields(
+					fieldWithPath("emojiType").type(STRING).description("이모지 타입"),
+					fieldWithPath("memberId").type(NUMBER).description("이모지를 남긴 회원 아이디"),
+					fieldWithPath("domain").type(STRING).description("이모지를 남긴 도메인"),
+					fieldWithPath("domainId").type(NUMBER).description("이모지를 남긴 도메인의 아이디")
+				))
+			);
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[200 성공] 이모지 저장(수정)")
+	void saveForUpdateEmojiIn(Domain domain) throws Exception {
+		//given
+		Long domainId = getDomainId(domain);
+		Type type = Type.ANGRY;
+		//when then
+		mockMvc.perform(
+				put("/{domain}/{domainId}/emojis", domain.name().toLowerCase(), domainId)
+					.header("Authorization", "Bearer " + accessToken)
+					.queryParam("type", type.name())
+					.contentType(APPLICATION_JSON)
+			)
+			.andExpect(status().isOk())
+			// .andExpect(jsonPath("$.emojiType").value(type.name()))
+			// .andExpect(jsonPath("$.memberId").value(savedMember.getId()))
+			// .andExpect(jsonPath("$.domain").value(domain.name()))
+			// .andExpect(jsonPath("$.domainId").value(domainId.longValue()))
+			.andDo(print())
+			.andDo(document("emoji save(Insert or Update)",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("domain").description("이모지를 남기려는 도메인(ex. 게시글, 댓글)"),
+					parameterWithName("domainId").description("이모지를 남기려는 도메인의 아이디")
+				),
+				queryParameters(
+					parameterWithName("type").description("이모지 타입(ex. SMILE, SAD..)")
+				),
+				responseFields(
+					fieldWithPath("emojiType").type(STRING).description("이모지 타입"),
+					fieldWithPath("memberId").type(NUMBER).description("이모지를 남긴 회원 아이디"),
+					fieldWithPath("domain").type(STRING).description("이모지를 남긴 도메인"),
+					fieldWithPath("domainId").type(NUMBER).description("이모지를 남긴 도메인의 아이디")
+				))
+			);
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[200 성공] 도메인에 속한 모든 이모지 조회")
+	void getAllEmojis(Domain domain) throws Exception {
+		//given
+		Long domainId = getDomainId(domain);
+
+		//when then
+		mockMvc.perform(
+				get("/{domain}/{domainId}/emojis", domain.name().toLowerCase(), domainId)
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(APPLICATION_JSON)
+			)
+			.andExpect(status().isOk())
+			.andDo(print())
+			.andDo(document("emoji get all",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("domain").description("이모지를 찾고 싶은 도메인"),
+					parameterWithName("domainId").description("이모지를 찾고 싶은 도메인의 아이디")
+				),
+				responseFields(
+					fieldWithPath("[].emojiType").type(STRING).description("이모지 타입"),
+					fieldWithPath("[].memberId").type(NUMBER).description("이모지를 남긴 회원 아이디"),
+					fieldWithPath("[].domain").type(STRING).description("이모지를 남긴 도메인"),
+					fieldWithPath("[].domainId").type(NUMBER).description("이모지를 남긴 도메인의 아이디")
+				))
+			);
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[204 성공] 이모지 삭제")
+	void deleteEmoji(Domain domain) throws Exception {
+		//given
+		Long domainId = getDomainId(domain);
+
+		//when then
+		mockMvc.perform(
+				delete("/{domain}/{domainId}/emojis", domain.name().toLowerCase(), domainId)
+					.header("Authorization", "Bearer " + accessToken)
+					.contentType(APPLICATION_JSON)
+			)
+			.andExpect(status().isNoContent())
+			.andDo(print())
+			.andDo(document("emoji delete",
+				getDocumentRequest(),
+				getDocumentResponse(),
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("domain").description("이모지를 삭제하려는 도메인"),
+					parameterWithName("domainId").description("이모지를 삭제하려는 도메인의 아이디")
+				))
+			);
+	}
+
+	private Long getDomainId(Domain domain) {
+		if (domain == Domain.POST) {
+			return savedPostExistEmoji.getId();
+		}
+		if (domain == Domain.COMMENT) {
+			return savedCommentExistEmoji.getId();
+		}
+		return null;
+	}
+
+	private Long getNotSavedEmojiDomainId(Domain domain) {
+		if (domain == Domain.POST) {
+			return savedPostNotExistEmoji.getId();
+		}
+		if (domain == Domain.COMMENT) {
+			return savedCommentNotExistEmoji.getId();
+		}
+		return null;
+	}
+
+}

--- a/src/test/java/com/clover/habbittracker/domain/emoji/entity/EmojiTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/emoji/entity/EmojiTest.java
@@ -1,0 +1,5 @@
+package com.clover.habbittracker.domain.emoji.entity;
+
+class EmojiTest {
+
+}

--- a/src/test/java/com/clover/habbittracker/domain/emoji/repository/EmojiCustomRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/emoji/repository/EmojiCustomRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.clover.habbittracker.domain.emoji.repository;
+
+import static com.clover.habbittracker.domain.emoji.entity.Emoji.*;
+import static com.clover.habbittracker.util.CommentProvider.*;
+import static com.clover.habbittracker.util.EmojiProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.clover.habbittracker.base.RepositoryTest;
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.comment.repository.CommentRepository;
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.clover.habbittracker.domain.post.repository.PostRepository;
+
+@DisplayName("Emoji Query 테스트")
+class EmojiCustomRepositoryTest extends RepositoryTest {
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
+	private EmojiRepository emojiRepository;
+
+	private Post savedPost;
+
+	private Comment savedComment;
+
+	@BeforeEach
+	void setUpDomain() {
+		// Post
+		savedPost = postRepository.save(createTestPost(savedMember));
+		emojiRepository.save(createTestEmojiInPost(savedMember, savedPost));
+
+		// Comment
+		savedComment = commentRepository.save(createTestComment(savedMember, savedPost));
+		emojiRepository.save(createTestEmojiInComment(savedMember, savedComment));
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[성공] 도메인과 도메인아이디로 할당된 이모지 전체 조회")
+	void findAllInDomain(Domain domain) {
+		// when
+		List<Emoji> emojiList = emojiRepository.findAllInDomain(domain, getDomainId(domain));
+
+		// then
+		assertThat(emojiList).isNotEmpty().hasSize(1);
+		assertThat(emojiList.get(0).getDomain()).isEqualTo(domain);
+		assertThat(emojiList.get(0).getDomainId()).isEqualTo(getDomainId(domain));
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[성공] 유니크 식별값으로 조회")
+	void findByUniqueKey(Domain domain) {
+		// when
+		Optional<Emoji> emoji =
+			emojiRepository.findByUniqueKey(savedMember.getId(), domain, getDomainId(domain));
+
+		// then
+		assertThat(emoji).isPresent();
+		assertThat(emoji.get().getDomain()).isEqualTo(domain);
+		assertThat(emoji.get().getDomainId()).isEqualTo(getDomainId(domain));
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[성공] 도메인에 할당된 이모지 개수 조회")
+	void countByDomain(Domain domain) {
+		// when
+		int count = emojiRepository.countByDomain(domain, getDomainId(domain));
+
+		// then
+		assertThat(count).isEqualTo(1);
+	}
+
+	private Long getDomainId(Domain domain) {
+		if (domain == Domain.POST) {
+			return savedPost.getId();
+		}
+		if (domain == Domain.COMMENT) {
+			return savedComment.getId();
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/emoji/service/EmojiServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/emoji/service/EmojiServiceTest.java
@@ -1,0 +1,130 @@
+package com.clover.habbittracker.domain.emoji.service;
+
+import static com.clover.habbittracker.domain.emoji.entity.Emoji.*;
+import static com.clover.habbittracker.util.CommentProvider.*;
+import static com.clover.habbittracker.util.EmojiProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.clover.habbittracker.base.ServiceTest;
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.comment.repository.CommentRepository;
+import com.clover.habbittracker.domain.emoji.dto.EmojiResponse;
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
+import com.clover.habbittracker.domain.emoji.repository.EmojiRepository;
+import com.clover.habbittracker.domain.post.entity.Post;
+import com.clover.habbittracker.domain.post.repository.PostRepository;
+
+@DisplayName("Emoji Service 테스트")
+class EmojiServiceTest extends ServiceTest {
+
+	@Autowired
+	private EmojiService emojiService;
+
+	@Autowired
+	private PostRepository postRepository;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
+	private EmojiRepository emojiRepository;
+
+	private Post savedPost;
+
+	private Comment savedComment;
+
+	@BeforeEach
+	@DisplayName("Domain Setting")
+	void setUpDomain() {
+		// Post
+		savedPost = postRepository.save(createTestPost(savedMember));
+		emojiRepository.save(createTestEmojiInPost(savedMember, savedPost));
+
+		// Comment
+		savedComment = commentRepository.save(createTestComment(savedMember, savedPost));
+		emojiRepository.save(createTestEmojiInComment(savedMember, savedComment));
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[성공] 도메인과 도메인아이디로 할당된 이모지 전체 조회")
+	void getAllEmojisInDomain(Domain domain) {
+		// when
+		List<EmojiResponse> allEmojis = emojiService.getAllEmojisInDomain(domain, getDomainId(domain));
+
+		// then
+		assertThat(allEmojis).hasSize(1);
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[성공] 이모지 저장(생성)")
+	void saveForInsert(Domain domain) {
+		// given
+		Type type = Type.SAD;
+
+		// when
+		EmojiResponse savedEmoji = emojiService.save(type, savedMember.getId(), domain, getDomainId(domain));
+
+		// then
+		assertThat(savedEmoji)
+			.hasFieldOrPropertyWithValue("emojiType", type.name())
+			.hasFieldOrPropertyWithValue("memberId", savedMember.getId())
+			.hasFieldOrPropertyWithValue("domain", domain.name())
+			.hasFieldOrPropertyWithValue("domainId", getDomainId(domain));
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[성공] 이모지 저장(수정)")
+	void saveForUpdate(Domain domain) {
+		// given
+		Type oldType = emojiRepository
+			.findByUniqueKey(savedMember.getId(), domain, getDomainId(domain))
+			.get().getType();
+
+		Type originType = Type.SAD; // 기존의 저장된 것과 다른 타입
+
+		// when
+		EmojiResponse newEmoji = emojiService.save(originType, savedMember.getId(), domain, getDomainId(domain));
+
+		// then
+		Type newType = Type.valueOf(newEmoji.emojiType());
+
+		assertThat(newType).isNotEqualTo(oldType);
+	}
+
+	@ParameterizedTest
+	@EnumSource(Domain.class)
+	@DisplayName("[성공] 이모지 취소")
+	void delete(Domain domain) {
+		// when
+		emojiService.delete(savedMember.getId(), domain, getDomainId(domain));
+
+		// then
+		Optional<Emoji> findEmoji
+			= emojiRepository.findByUniqueKey(savedMember.getId(), domain, getDomainId(domain));
+
+		assertThat(findEmoji).isEmpty();
+	}
+
+	private Long getDomainId(Domain domain) {
+		if (domain == Domain.POST) {
+			return savedPost.getId();
+		}
+		if (domain == Domain.COMMENT) {
+			return savedComment.getId();
+		}
+		return null;
+	}
+}

--- a/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/api/HabitControllerTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.habit.api;
 
-import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.ApiDocumentUtils.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.hamcrest.core.Is.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;

--- a/src/test/java/com/clover/habbittracker/domain/habit/repository/HabitRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/repository/HabitRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.habit.repository;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;

--- a/src/test/java/com/clover/habbittracker/domain/habit/service/HabitServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/habit/service/HabitServiceTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.habit.service;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,20 +33,16 @@ import com.clover.habbittracker.domain.member.repository.MemberRepository;
 @Transactional
 public class HabitServiceTest {
 
+	private final LocalDateTime now = LocalDateTime.now();
 	@Autowired
 	private HabitService habitService;
-
 	@Autowired
 	private HabitRepository habitRepository;
-
 	@Autowired
 	private HabitCheckRepository habitCheckRepository;
 	@Autowired
 	private MemberRepository memberRepository;
-
 	private Member testMember;
-
-	private final LocalDateTime now = LocalDateTime.now();
 
 	@BeforeEach
 	void setUp() {
@@ -89,7 +85,6 @@ public class HabitServiceTest {
 		habitService.register(testMemberId, habitRequest);
 		String today = now.getYear() + "-0" + now.getMonthValue();
 
-
 		//when
 		List<MyHabitResponse> myList1 = habitService.getMyList(testMemberId, "2023-04"); // 2023년 4월로 조회.
 		List<MyHabitResponse> myList2 = habitService.getMyList(testMemberId, today);
@@ -100,7 +95,6 @@ public class HabitServiceTest {
 				.hasFieldOrProperty("id")
 				.hasFieldOrProperty("content")
 		);
-
 
 		myList2.forEach(myHabitResponse ->
 			assertThat(myHabitResponse)
@@ -137,7 +131,7 @@ public class HabitServiceTest {
 		Long saveHabitId = habitService.register(testMemberId, habitRequest);
 
 		//when
-		habitService.habitCheck(saveHabitId ,today);
+		habitService.habitCheck(saveHabitId, today);
 		Habit saveHabit = habitRepository.findById(saveHabitId).get();
 
 		//then
@@ -156,9 +150,9 @@ public class HabitServiceTest {
 		String today = "0" + now.getMonthValue() + "-" + now.getDayOfMonth();
 
 		//when
-		habitService.habitCheck(saveHabitId,today);
+		habitService.habitCheck(saveHabitId, today);
 		assertThrows(HabitCheckDuplicateException.class,
-			() -> habitService.habitCheck(saveHabitId,today)); // 같은 날 두번 연속 체크는 불가능.
+			() -> habitService.habitCheck(saveHabitId, today)); // 같은 날 두번 연속 체크는 불가능.
 	}
 
 	@Test
@@ -173,7 +167,7 @@ public class HabitServiceTest {
 
 		//when
 		assertThrows(HabitCheckExpiredException.class,
-			() -> habitService.habitCheck(saveHabitId,past));
+			() -> habitService.habitCheck(saveHabitId, past));
 	}
 
 	@Test
@@ -205,7 +199,7 @@ public class HabitServiceTest {
 
 		//when then
 		assertAll(
-			() -> assertThrows(HabitNotFoundException.class, () -> habitService.habitCheck(wrongHabitId , today)),
+			() -> assertThrows(HabitNotFoundException.class, () -> habitService.habitCheck(wrongHabitId, today)),
 			() -> assertThrows(HabitNotFoundException.class,
 				() -> habitService.updateMyHabit(wrongHabitId, habitRequest))
 		);

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.member.api;
 
-import static com.clover.habbittracker.global.util.ApiDocumentUtils.*;
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.ApiDocumentUtils.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.hamcrest.core.Is.*;
 import static org.springframework.http.MediaType.*;
@@ -78,6 +78,7 @@ public class MemberControllerTest {
 				)
 			));
 	}
+
 	@Test
 	@DisplayName("기존의 사용하고 있는 닉네임은 중복으로 생각하여 예외가 발생한다.")
 	void updateNickNameDuplicateTest() throws Exception {
@@ -101,6 +102,7 @@ public class MemberControllerTest {
 					fieldWithPath("msg").type(STRING).description("결과 메시지")
 				)));
 	}
+
 	@Test
 	@DisplayName("사용자는 자신의 프로필 닉네임만 변경할 수 있다.")
 	void updateMyProfileNickNameTest() throws Exception {
@@ -134,6 +136,7 @@ public class MemberControllerTest {
 				)
 			));
 	}
+
 	@Test
 	@DisplayName("사용자는 자신의 프로필 정보를 삭제 할 수 있다.")
 	void deleteProfileTest() throws Exception {

--- a/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.member.repository;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;

--- a/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/service/MemberServiceTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.member.service;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,7 +33,6 @@ class MemberServiceTest {
 	void setUp() {
 		saveId = memberRepository.save(createTestMember()).getId();
 	}
-
 
 	@Test
 	@DisplayName("사용자 ID로 사용자 프로필 정보를 얻어 올 수 있다.")

--- a/src/test/java/com/clover/habbittracker/domain/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/mapper/PostMapperTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.post.mapper;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
@@ -1,13 +1,17 @@
 package com.clover.habbittracker.domain.post.repository;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,30 +107,30 @@ public class PostRepositoryTest {
 		assertThat(dailyPostsSummary.get(0)).usingRecursiveComparison().isEqualTo(savePostDaily);
 	}
 
-	// TODO: 조회수 개선 이후 테스트 진행. 현재 정상적으로 테스트가 불가능.
-	// @Test
-	// @DisplayName("게시글의 조회수는 1씩 증가한다.")
-	// void updateViewTest() throws InterruptedException {
-	// 	//given
-	// 	int threadNum = 3;
-	// 	Post testPost = createTestPost(testMember);
-	// 	Post savedPost = postRepository.save(testPost);
-	//
-	// 	ExecutorService executorService = Executors.newFixedThreadPool(threadNum);
-	// 	CountDownLatch latch = new CountDownLatch(threadNum);
-	//
-	// 	//when
-	// 	for (int i = 0; i < threadNum; i++) {
-	// 		executorService.execute(() -> {
-	// 			postRepository.updateViews(savedPost.getId());
-	// 			latch.countDown();
-	// 		});
-	// 	}
-	// 	latch.await();
-	//
-	// 	//then
-	// 	assertThat(savedPost.getViews()).isEqualTo(1);
-	// }
+	@Disabled // TODO: 조회수 개선 이후 테스트 진행. 현재 정상적으로 테스트가 불가능.
+	@Test
+	@DisplayName("게시글의 조회수는 1씩 증가한다.")
+	void updateViewTest() throws InterruptedException {
+		//given
+		int threadNum = 3;
+		Post testPost = createTestPost(testMember);
+		Post savedPost = postRepository.save(testPost);
+
+		ExecutorService executorService = Executors.newFixedThreadPool(threadNum);
+		CountDownLatch latch = new CountDownLatch(threadNum);
+
+		//when
+		for (int i = 0; i < threadNum; i++) {
+			executorService.execute(() -> {
+				postRepository.updateViews(savedPost.getId());
+				latch.countDown();
+			});
+		}
+		latch.await();
+
+		//then
+		assertThat(savedPost.getViews()).isEqualTo(1);
+	}
 
 	@Test
 	void searchByPostTest() {

--- a/src/test/java/com/clover/habbittracker/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/service/PostServiceTest.java
@@ -1,7 +1,7 @@
 package com.clover.habbittracker.domain.post.service;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
-import static com.clover.habbittracker.global.util.PostProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
+import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -34,18 +34,14 @@ import com.clover.habbittracker.domain.post.repository.PostRepository;
 @Transactional
 public class PostServiceTest {
 
+	private final Pageable pageable = PageRequest.of(0, 15);
 	@Autowired
 	private PostRepository postRepository;
-
 	@Autowired
 	private PostService postService;
-
 	@Autowired
 	private MemberRepository memberRepository;
-
 	private Member testMember;
-
-	private final Pageable pageable = PageRequest.of(0, 15);
 
 	@BeforeEach
 	public void setUp() {

--- a/src/test/java/com/clover/habbittracker/global/infra/ObjectStorageServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/global/infra/ObjectStorageServiceTest.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.infra;
+package com.clover.habbittracker.global.infra;
 
 import static org.mockito.Mockito.*;
 
@@ -16,7 +16,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.clover.habbittracker.global.infra.ObjectStorageService;
 
 public class ObjectStorageServiceTest {
 	private ObjectStorageService objectStorageService;

--- a/src/test/java/com/clover/habbittracker/global/security/oauth/service/OauthServiceTest.java
+++ b/src/test/java/com/clover/habbittracker/global/security/oauth/service/OauthServiceTest.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.global.security.oauth.service;
 
-import static com.clover.habbittracker.global.util.MemberProvider.*;
+import static com.clover.habbittracker.util.MemberProvider.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;

--- a/src/test/java/com/clover/habbittracker/util/ApiDocumentUtils.java
+++ b/src/test/java/com/clover/habbittracker/util/ApiDocumentUtils.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.global.util;
+package com.clover.habbittracker.util;
 
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 
@@ -8,6 +8,7 @@ import org.springframework.restdocs.operation.preprocess.OperationResponsePrepro
 public class ApiDocumentUtils {
 
 	private ApiDocumentUtils() {
+		/* NO-OP */
 	}
 
 	public static OperationRequestPreprocessor getDocumentRequest() {

--- a/src/test/java/com/clover/habbittracker/util/CommentProvider.java
+++ b/src/test/java/com/clover/habbittracker/util/CommentProvider.java
@@ -1,0 +1,22 @@
+package com.clover.habbittracker.util;
+
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.post.entity.Post;
+
+public class CommentProvider {
+
+	private static final String COMMENT_CONTENT = "testContent";
+
+	private CommentProvider() {
+		/* NO-OP */
+	}
+
+	public static Comment createTestComment(Member savedMember, Post savedPost) {
+		return Comment.builder()
+			.content(COMMENT_CONTENT)
+			.member(savedMember)
+			.post(savedPost)
+			.build();
+	}
+}

--- a/src/test/java/com/clover/habbittracker/util/EmojiProvider.java
+++ b/src/test/java/com/clover/habbittracker/util/EmojiProvider.java
@@ -1,0 +1,31 @@
+package com.clover.habbittracker.util;
+
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
+import com.clover.habbittracker.domain.member.entity.Member;
+import com.clover.habbittracker.domain.post.entity.Post;
+
+public class EmojiProvider {
+
+	private EmojiProvider() {
+		/* NO-OP */
+	}
+
+	public static Emoji createTestEmojiInPost(Member savedMember, Post savedPost) {
+		return Emoji.builder()
+			.type(Emoji.Type.SMILE)
+			.memberId(savedMember.getId())
+			.domain(Emoji.Domain.POST)
+			.domainId(savedPost.getId())
+			.build();
+	}
+
+	public static Emoji createTestEmojiInComment(Member savedMember, Comment savedComment) {
+		return Emoji.builder()
+			.type(Emoji.Type.SMILE)
+			.memberId(savedMember.getId())
+			.domain(Emoji.Domain.COMMENT)
+			.domainId(savedComment.getId())
+			.build();
+	}
+}

--- a/src/test/java/com/clover/habbittracker/util/MemberProvider.java
+++ b/src/test/java/com/clover/habbittracker/util/MemberProvider.java
@@ -1,14 +1,19 @@
-package com.clover.habbittracker.global.util;
+package com.clover.habbittracker.util;
 
 import com.clover.habbittracker.domain.member.entity.Member;
 
 public class MemberProvider {
+
 	private static final Long ID = 1L;
 	private static final String EMAIL = "test@email.com";
 	private static final String PROFILE_IMG_URL = "testImgUrl";
 	private static final String NICK_NAME = "testNickName";
 	private static final String OAUTH_ID = "testOauthId";
 	private static final String PROVIDER = "testProvider";
+
+	private MemberProvider() {
+		/* NO-OP */
+	}
 
 	public static Member createTestMember() {
 		return Member.builder()

--- a/src/test/java/com/clover/habbittracker/util/PostProvider.java
+++ b/src/test/java/com/clover/habbittracker/util/PostProvider.java
@@ -1,4 +1,4 @@
-package com.clover.habbittracker.global.util;
+package com.clover.habbittracker.util;
 
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
@@ -11,6 +11,10 @@ public class PostProvider {
 	private static final String REQUEST_TITLE = "requestTitle";
 	private static final String REQUEST_CONTENT = "requestContent";
 	private static final Post.Category CATEGORY = Post.Category.DAILY;
+
+	private PostProvider() {
+		/* NO-OP */
+	}
 
 	public static Post createTestPost(Member member) {
 		return Post.builder()


### PR DESCRIPTION
## 작업 사항

### 리팩터링 수행
- [feat(Emoji): 리팩터링 작업 수행](https://github.com/Clover-Habiters/backend/pull/30/commits/764c7314bc4b375b249ce976fcdb41d671f49527)

- `도메인 중심 API에서 기능(메서드)중심 API`로 변경했습니다.
  - 이러한 방식이 `확장성`이 높다고 생각했습니다.
  
  - 이모지 반응을 추가할 수 있는 (예, 루틴, 습관, 등..) 도메인이 늘어나더라도 메서드에는 변경이 필요 없기 때문입니다.

  - 그리고 기존에 하나의 메서드에서 `생성과 삭제를 동시에 처리`했는데 이는 RESTful하지 않다고 생각합니다. `클릭에 따른 처리는 프론트에서 하는게 옳지 않을까 생각`하는데 @gombasan 님은 어떻게 생각하시나요?

- `Save API`를 `PutMapping`으로 요청 받아 `생성 혹은 수정`할 수 있도록 구현했습니다. `멱등성`을 지키기 위해서 이러한 방식을 적용하였습니다.

- `FK는 제거하고 index로 처리했습니다.` (회원 ID)
  - 검색에 주로 사용되는 필드는 `인덱스를 추가`했습니다.(도메인과 도메인ID)
  
  - 중복 처리를 막기 위해 `[도메인과 도메인ID, 회원 ID]를 합쳐서 식별자(Unique)`로 두었습니다.  

- `webConfig` 설정을 변경했습니다.
  - `EnableWebMvc` 적용했습니다. 

- **이모지를 활용할 수 있는 기능들을 추가** 했습니다. 궁금한 사항에 대해 댓글로 알려주세요!

### 테스트 코드 추가
`Controller` 
- RestDocs 적용

- Enum 문서화는 태희님이 도와주실거라고 믿습니다.

`Service` 
- SpringBootTest 적용

`Repository` 
- DataJPATest 적용, 쿼리 확인

#### 각 레이어 별 테스트 완료 했습니다.
- 혹시 더 테스트해볼게 있을까요? 

### 이슈
- close #5 