### PR TITLE
Fix(Web)-정적-리소스-핸들러-추가

### DIFF
--- a/src/main/java/com/clover/habbittracker/global/config/web/WebConfig.java
+++ b/src/main/java/com/clover/habbittracker/global/config/web/WebConfig.java
@@ -5,6 +5,7 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.clover.habbittracker.domain.emoji.entity.Emoji;
@@ -17,6 +18,12 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addFormatters(FormatterRegistry registry) {
 		registry.addConverter(new Emoji.Domain.StringToEmojiDomainConverter());
 		registry.addConverter(new Emoji.Type.StringToEmojiTypeConverter());
+	}
+
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry.addResourceHandler("/docs/**")
+			.addResourceLocations("classpath:/static/");
 	}
 
 	@Override

--- a/src/test/java/com/clover/habbittracker/global/restdocs/common/CommonDocController.java
+++ b/src/test/java/com/clover/habbittracker/global/restdocs/common/CommonDocController.java
@@ -15,7 +15,7 @@ import com.clover.habbittracker.global.restdocs.enums.EnumDocs;
 import com.clover.habbittracker.global.restdocs.enums.EnumResponse;
 
 @RestController
-@RequestMapping("/docs")
+@RequestMapping("/test/docs")
 public class CommonDocController {
 
 	@GetMapping("/enums")

--- a/src/test/java/com/clover/habbittracker/global/restdocs/enums/EnumDocumentation.java
+++ b/src/test/java/com/clover/habbittracker/global/restdocs/enums/EnumDocumentation.java
@@ -22,10 +22,26 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 public class EnumDocumentation extends RestDocsSupport {
 
+	// 커스텀 템플릿 사용을 위한 함수
+	public static CustomResponseFieldsSnippet customResponseFields
+	(String type,
+		PayloadSubsectionExtractor<?> subsectionExtractor,
+		Map<String, Object> attributes, FieldDescriptor... descriptors) {
+		return new CustomResponseFieldsSnippet(type, subsectionExtractor, Arrays.asList(descriptors), attributes
+			, true);
+	}
+
+	// Map으로 넘어온 enumValue를 fieldWithPath로 변경하여 리턴
+	private static FieldDescriptor[] enumConvertFieldDescriptor(Map<String, String> enumValues) {
+		return enumValues.entrySet().stream()
+			.map(x -> fieldWithPath(x.getKey()).description(x.getValue()))
+			.toArray(FieldDescriptor[]::new);
+	}
+
 	@Test
 	public void enums() throws Exception {
 		ResultActions result = this.mockMvc.perform(
-			get("/docs/enums")
+			get("/test/docs/enums")
 				.contentType(MediaType.APPLICATION_JSON)
 		);
 
@@ -52,22 +68,6 @@ public class EnumDocumentation extends RestDocsSupport {
 					enumConvertFieldDescriptor((enumDocs.getCategory()))
 				)
 			));
-	}
-
-	// 커스텀 템플릿 사용을 위한 함수
-	public static CustomResponseFieldsSnippet customResponseFields
-	(String type,
-		PayloadSubsectionExtractor<?> subsectionExtractor,
-		Map<String, Object> attributes, FieldDescriptor... descriptors) {
-		return new CustomResponseFieldsSnippet(type, subsectionExtractor, Arrays.asList(descriptors), attributes
-			, true);
-	}
-
-	// Map으로 넘어온 enumValue를 fieldWithPath로 변경하여 리턴
-	private static FieldDescriptor[] enumConvertFieldDescriptor(Map<String, String> enumValues) {
-		return enumValues.entrySet().stream()
-			.map(x -> fieldWithPath(x.getKey()).description(x.getValue()))
-			.toArray(FieldDescriptor[]::new);
 	}
 
 	// mvc result 데이터 파싱


### PR DESCRIPTION
@EnableWebMvc를 적용하였기 때문에 정적 리소스를 조회하기 위해서는 리소스 핸들러 매핑을 등록해야합니다~!

따라서, 기존 경로와 같을 수 있도록` /docs` 로 요청이 오면 `/static`으로 연결할 수 있도록 하였습니다~! 확인 부탁드립니다~