### PR TITLE
[#35] Refactor : 로그 설정 변경

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - db
     ports:
       - "8080:8080"
+    volumes:
+      - ./.log:/.log
     environment:
       DB_USER_NAME: ${DB_USER_NAME}
       DB_PASSWORD: ${DB_PASSWORD}
@@ -66,6 +68,8 @@ services:
       - db
     ports:
       - "8081:8080"
+    volumes:
+      - ./.log:/.log
     environment:
       DB_USER_NAME: ${DB_USER_NAME}
       DB_PASSWORD: ${DB_PASSWORD}

--- a/src/main/java/com/clover/habbittracker/global/infra/log/MyLogger.java
+++ b/src/main/java/com/clover/habbittracker/global/infra/log/MyLogger.java
@@ -1,5 +1,6 @@
 package com.clover.habbittracker.global.infra.log;
 
+import static com.clover.habbittracker.global.infra.log.MyLogger.ClientIPHeader.*;
 import static org.springframework.web.servlet.HandlerMapping.*;
 
 import org.springframework.web.method.HandlerMethod;
@@ -15,7 +16,7 @@ public class MyLogger {
 
 	private static final String LOG_FORM = "[{}]: Called By method [{}] Cause : {} id = {}";
 
-	private static final String COMMON_LOG_FORM = "[{}]: Called By method {} Cause : {}";
+	private static final String COMMON_LOG_FORM = "[{}]: Called By method {} Cause : {} Reason : {} client IP : {}";
 
 	public static void warnExceptionLogging(HttpServletRequest request, BaseException e) {
 		ErrorType errorType = e.getErrorType();
@@ -28,15 +29,42 @@ public class MyLogger {
 	public static void commonExceptionWarnLogging(HttpServletRequest request, Exception e, ErrorType errorType) {
 		String methodName
 			= ((HandlerMethod)request.getAttribute(BEST_MATCHING_HANDLER_ATTRIBUTE)).getMethod().getName();
-
-		log.warn(COMMON_LOG_FORM, e.getClass().getSimpleName(), methodName, errorType.getErrorMsg());
+		String clientIP = getClientIP(request);
+		log.warn(COMMON_LOG_FORM, e.getClass().getSimpleName(), methodName, errorType.getErrorMsg(), e.getMessage(),
+			clientIP);
 	}
 
 	public static void commonExceptionErrorLogging(HttpServletRequest request, Exception e, ErrorType errorType) {
 		String methodName
 			= ((HandlerMethod)request.getAttribute(BEST_MATCHING_HANDLER_ATTRIBUTE)).getMethod().getName();
-
-		log.warn(COMMON_LOG_FORM, e.getClass().getSimpleName(), methodName, errorType.getErrorMsg());
+		String clientIP = getClientIP(request);
+		log.warn(COMMON_LOG_FORM, e.getClass().getSimpleName(), methodName, errorType.getErrorMsg(), e.getMessage(),
+			clientIP);
 	}
 
+	public enum ClientIPHeader {
+		X_FORWARDED_FOR("X-Forwarded-For"),
+		PROXY_CLIENT_IP("Proxy-Client-IP"),
+		WL_PROXY_CLIENT_IP("WL-Proxy-Client-IP"),
+		HTTP_CLIENT_IP("HTTP_CLIENT_IP"),
+		HTTP_X_FORWARDED_FOR("HTTP_X_FORWARDED_FOR"),
+		REMOTE_ADDR(null);
+
+		private final String headerName;
+
+		ClientIPHeader(String headerName) {
+			this.headerName = headerName;
+		}
+
+		public static String getClientIP(HttpServletRequest request) {
+			String ip = null;
+			for (ClientIPHeader header : values()) {
+				ip = request.getHeader(header.headerName);
+			}
+			if (ip == null) {
+				ip = request.getRemoteAddr();
+			}
+			return ip;
+		}
+	}
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -42,6 +42,33 @@
             <!-- 로그 파일 최대 보관 크기. 최대 크기를 초과하면 가장 오래된 로그 자동 제거 -->
             <totalSizeCap>20GB</totalSizeCap>
         </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>DENY</onMatch>
+        </filter>
+    </appender>
+
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 파일 경로 설정 -->
+        <file>${LOG_PATH}/${LOG_FILE_NAME}_error.log</file>
+        <!-- 출력패턴 설정-->
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <!-- Rolling 정책 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- .gz,.zip 등을 넣으면 자동 일자별 로그파일 압축 -->
+            <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_error.log</fileNamePattern>
+            <!-- 일자별 로그파일 최대 보관주기(~일), 해당 설정일 이상된 파일은 자동으로 제거-->
+            <!-- <maxHistory>30</maxHistory> -->
+            <!-- 로그 파일 최대 보관 크기. 최대 크기를 초과하면 가장 오래된 로그 자동 제거 -->
+            <totalSizeCap>20GB</totalSizeCap>
+        </rollingPolicy>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
     </appender>
 
     <!-- 로그 전역 세팅 -->
@@ -50,5 +77,7 @@
         <appender-ref ref="CONSOLE"/>
         <!-- 위에 설정한 파일 설정 추가 -->
         <appender-ref ref="FILE"/>
+
+        <appender-ref ref="ERROR_FILE"/>
     </root>
 </configuration>


### PR DESCRIPTION
## 작업 사항
- #35 -> 로그 설정 내용이 해당 이슈와 어울린다고 생각하여 해당 이슈로 설정했습니다!!

### 작업 내용
[refactor : logback 설정](https://github.com/Clover-Habiters/backend/commit/d71f43b1031dc30a13621c9ecb1fd52e5d06eef5)
- 기존 로그파일 저장에서 ERROR level 은 따로 저장하여 관리하도록 수정했습니다.
- 많은 로그 정보내에서 error 를 찾는것보다 파일을 따로 지정하여 관리함으로 운영상 더 편할거라고 생각하여 적용해봤습니다

[refactor : 로그 출력 FORM 수정](https://github.com/Clover-Habiters/backend/commit/254c229b1582ec3131359b1e9228e0adc261f41d) 
- 기존 로그 출력 부분에서 서버 에러일 경우 단순하게 `서버에러입니다` 와 메서드 이름만을 출력하니 로그 내용울 분석하는것이 거의 불가능하다 생각하여, 에러의 메세지를 추가로 더 출력하도록 수정하였습니다.
- 최근 서버 공격을 받고있다는 알람 및 로그가 확인되어 클라이언트의 ip 를 로그로 출력하도록 설정하였습니다.

[config : log 디렉토리 volumes 설정 추가](https://github.com/Clover-Habiters/backend/commit/6a9b88a5337e11c716202d4aa125510a294337bf) 
- log 디렉토리를 도커 컨테이너 내부가 아닌 서버에서 확인 할 수 있도록 volumes 설정을 추가하였습니다.


## 리뷰 포인트
- 로그에서 error 내용만 따로 뽑아서 관리하도록 설정해봤는데 괜찮은 방법인지 궁금합니다~~괜히 파일만 늘어나는게 아닌가 싶네요!