### PR TITLE
[#46] FIX : 댓글 오류 수정

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
@@ -3,12 +3,16 @@ package com.clover.habbittracker.domain.comment.dto;
 import static com.fasterxml.jackson.annotation.JsonFormat.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import com.clover.habbittracker.domain.emoji.dto.EmojiResponse;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record CommentResponse(
 	Long id,
 	String content,
+
+	List<EmojiResponse> emojis,
 	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDateTime createDate,
 	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")

--- a/src/main/java/com/clover/habbittracker/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/mapper/CommentMapper.java
@@ -24,11 +24,7 @@ public interface CommentMapper {
 		@Mapping(source = "request.content", target = "content"),
 		@Mapping(source = "member", target = "member")
 	})
-	Comment toReply(CommentRequest request, Member member, Post post, Long commentId);
+	Comment toReply(CommentRequest request, Member member, Post post, Long parentId);
 
-	@Mappings({
-		@Mapping(source = "comment.createdAt", target = "createDate"),
-		@Mapping(source = "comment.updatedAt", target = "updateDate")
-	})
 	CommentResponse toCommentResponse(Comment comment);
 }

--- a/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/dto/DiaryResponse.java
@@ -24,7 +24,7 @@ public class DiaryResponse {
 		return DiaryResponse.builder()
 			.id(diary.getId())
 			.content(diary.getContent())
-			.createDate(diary.getCreatedAt())
+			.createDate(diary.getCreateDate())
 			.endUpdateDate(diary.getEndUpdateDate())
 			.build();
 	}

--- a/src/main/java/com/clover/habbittracker/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/diary/repository/DiaryRepository.java
@@ -9,14 +9,15 @@ import org.springframework.data.repository.query.Param;
 
 import com.clover.habbittracker.domain.diary.entity.Diary;
 
-public interface DiaryRepository extends JpaRepository<Diary,Long> {
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	@Query("""
 			SELECT d
 			FROM Diary d
 			WHERE d.member.id = :memberId
-			AND d.createdAt BETWEEN :start AND :end
-			ORDER BY d.createdAt DESC
+			AND d.createDate BETWEEN :start AND :end
+			ORDER BY d.createDate DESC
 		""")
-	List<Diary> findByMemberId(@Param("memberId") Long memberId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+	List<Diary> findByMemberId(@Param("memberId") Long memberId, @Param("start") LocalDateTime start,
+		@Param("end") LocalDateTime end);
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/dto/HabitResponse.java
@@ -22,7 +22,7 @@ public class HabitResponse {
 		return HabitResponse.builder()
 			.id(habit.getId())
 			.content(habit.getContent())
-			.createDate(habit.getCreatedAt())
+			.createDate(habit.getCreateDate())
 			.build();
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/habit/dto/MyHabitResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/dto/MyHabitResponse.java
@@ -24,10 +24,10 @@ public class MyHabitResponse {
 		return MyHabitResponse.builder()
 			.id(habit.getId())
 			.content(habit.getContent())
-			.createDate(habit.getCreatedAt())
+			.createDate(habit.getCreateDate())
 			.habitChecks(HabitCheckResponse.from(habit.getHabitChecks().stream()
-				.filter(habitCheck -> habitCheck.getCreatedAt().isBefore(dateMap.get("end")))
-				.filter(habitCheck -> habitCheck.getCreatedAt().isAfter(dateMap.get("start")))
+				.filter(habitCheck -> habitCheck.getCreateDate().isBefore(dateMap.get("end")))
+				.filter(habitCheck -> habitCheck.getCreateDate().isAfter(dateMap.get("start")))
 				.toList()))
 			.build();
 	}

--- a/src/main/java/com/clover/habbittracker/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/habit/service/HabitServiceImpl.java
@@ -59,7 +59,7 @@ public class HabitServiceImpl implements HabitService {
 	@Transactional
 	public HabitResponse updateMyHabit(Long habitId, HabitRequest request) {
 		Habit habit = habitRepository.findById(habitId)
-			.orElseThrow(()-> new HabitNotFoundException(habitId));
+			.orElseThrow(() -> new HabitNotFoundException(habitId));
 		habit.setContent(request.getContent());
 		return HabitResponse.from(habit);
 	}
@@ -68,7 +68,7 @@ public class HabitServiceImpl implements HabitService {
 	@Transactional
 	public void habitCheck(Long habitId, String date) {
 		Habit habit = habitRepository.findById(habitId)
-			.orElseThrow(()-> new HabitNotFoundException(habitId));
+			.orElseThrow(() -> new HabitNotFoundException(habitId));
 		LocalDate requestDate = DateUtil.getLocalDate(date);
 		if (!isToday(requestDate)) {
 			throw new HabitCheckExpiredException(habitId);
@@ -76,13 +76,13 @@ public class HabitServiceImpl implements HabitService {
 
 		habitCheckRepository.findByHabitOrderByUpdatedAtDesc(habit)
 			.ifPresent(lastHabitCheck -> {
-				if (isToday(lastHabitCheck.getUpdatedAt().toLocalDate())) {
-					System.out.println(lastHabitCheck.getUpdatedAt());
+				if (isToday(lastHabitCheck.getUpdateDate().toLocalDate())) {
+					System.out.println(lastHabitCheck.getUpdateDate());
 					throw new HabitCheckDuplicateException(habitId);
 				}
 			});
 		habitCheckRepository.save(HabitCheck.builder().checked(true).habit(habit).build());
-		habit.setUpdatedAt(LocalDateTime.now());
+		habit.setUpdateDate(LocalDateTime.now());
 	}
 
 	@Override

--- a/src/main/java/com/clover/habbittracker/domain/habitcheck/dto/HabitCheckResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/habitcheck/dto/HabitCheckResponse.java
@@ -24,7 +24,7 @@ public class HabitCheckResponse {
 		return habitChecks.stream()
 			.map(habitCheck -> new HabitCheckResponse(
 				habitCheck.getId(),
-				habitCheck.getUpdatedAt()
+				habitCheck.getUpdateDate()
 			)).toList();
 	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/habitcheck/repository/HabitCheckRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/habitcheck/repository/HabitCheckRepository.java
@@ -14,8 +14,8 @@ public interface HabitCheckRepository extends JpaRepository<HabitCheck, Long> {
 	@Query("""
 		SELECT hc
 		FROM HabitCheck hc
-		WHERE hc.updatedAt = (
-		 	SELECT MAX(subHc.updatedAt)
+		WHERE hc.updateDate = (
+		 	SELECT MAX(subHc.updateDate)
 		  	FROM HabitCheck subHc
 		  	WHERE subHc.habit = :habit
 		)

--- a/src/main/java/com/clover/habbittracker/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/mapper/PostMapper.java
@@ -25,15 +25,10 @@ public interface PostMapper {
 	@Mappings({
 		@Mapping(source = "post.comments", target = "numOfComments", qualifiedByName = "commentsToSize"),
 		@Mapping(source = "post.emojis", target = "numOfEmojis", qualifiedByName = "emojisToSize"),
-		@Mapping(source = "post.createdAt", target = "createDate")
 	})
 	PostResponse toPostResponse(Post post);
 
-	@Mappings({
-		@Mapping(source = "post.member.id", target = "memberId"),
-		@Mapping(source = "post.createdAt", target = "createDate"),
-		@Mapping(source = "post.updatedAt", target = "updateDate")
-	})
+	@Mapping(source = "post.member.id", target = "memberId")
 	PostDetailResponse toPostDetail(Post post);
 
 	@Named("commentsToSize")

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
@@ -39,7 +39,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 			.where(eqCategory(category))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
-			.orderBy(post.createdAt.desc())
+			.orderBy(post.createDate.desc())
 			.fetch();
 	}
 
@@ -74,7 +74,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 			)
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
-			.orderBy(post.createdAt.desc())
+			.orderBy(post.createDate.desc())
 			.distinct()
 			.fetch();
 

--- a/src/main/java/com/clover/habbittracker/global/base/entity/BaseEntity.java
+++ b/src/main/java/com/clover/habbittracker/global/base/entity/BaseEntity.java
@@ -21,15 +21,15 @@ public abstract class BaseEntity {
 
 	@CreatedDate
 	@Column(name = "created_date", updatable = false)
-	private LocalDateTime createdAt;
+	private LocalDateTime createDate;
 
 	@LastModifiedDate
 	@Column(name = "updated_date")
-	private LocalDateTime updatedAt;
+	private LocalDateTime updateDate;
 
 	private boolean deleted;
 
-	public void setUpdatedAt(LocalDateTime updatedAt) {
-		this.updatedAt = updatedAt;
+	public void setUpdateDate(LocalDateTime updatedDate) {
+		this.updateDate = updatedDate;
 	}
 }

--- a/src/test/java/com/clover/habbittracker/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/api/CommentControllerTest.java
@@ -68,12 +68,12 @@ class CommentControllerTest extends RestDocsSupport {
 						.attributes(field("constraints", "아직 미정"))
 				),
 				responseFields(
-					fieldWithPath("code").type(STRING).description("결과 코드"),
-					fieldWithPath("message").type(STRING).description("결과 메시지"),
-					fieldWithPath("data.id").type(NUMBER).description("생성된 댓글 아이디"),
-					fieldWithPath("data.content").type(STRING).description("생성된 댓글 내용"),
-					fieldWithPath("data.createDate").type(STRING).description("댓글 생성 날짜"),
-					fieldWithPath("data.updateDate").type(STRING).description("댓글 최근 수정 날짜")
+					beneathPath("data").withSubsectionId("data"),
+					fieldWithPath("id").type(NUMBER).description("생성된 댓글 아이디"),
+					fieldWithPath("content").type(STRING).description("생성된 댓글 내용"),
+					fieldWithPath("emojis[]").type(ARRAY).description("댓글에 대한 이모지"),
+					fieldWithPath("createDate").type(STRING).description("댓글 생성 날짜"),
+					fieldWithPath("updateDate").type(STRING).description("댓글 최근 수정 날짜")
 				)));
 	}
 
@@ -111,12 +111,12 @@ class CommentControllerTest extends RestDocsSupport {
 						.attributes(field("constraints", "아직 미정"))
 				),
 				responseFields(
-					fieldWithPath("code").type(STRING).description("결과 코드"),
-					fieldWithPath("message").type(STRING).description("결과 메시지"),
-					fieldWithPath("data.id").type(NUMBER).description("생성된 댓글 아이디"),
-					fieldWithPath("data.content").type(STRING).description("생성된 댓글 내용"),
-					fieldWithPath("data.createDate").type(STRING).description("댓글 생성 날짜"),
-					fieldWithPath("data.updateDate").type(STRING).description("댓글 최근 수정 날짜")
+					beneathPath("data").withSubsectionId("data"),
+					fieldWithPath("id").type(NUMBER).description("생성된 댓글 아이디"),
+					fieldWithPath("content").type(STRING).description("생성된 댓글 내용"),
+					fieldWithPath("emojis[]").type(ARRAY).description("댓글의 이모지"),
+					fieldWithPath("createDate").type(STRING).description("댓글 생성 날짜"),
+					fieldWithPath("updateDate").type(STRING).description("댓글 최근 수정 날짜")
 				)));
 	}
 
@@ -193,12 +193,12 @@ class CommentControllerTest extends RestDocsSupport {
 					parameterWithName("commentId").description("답글을 조회 할 댓글 id")
 				),
 				responseFields(
-					fieldWithPath("code").type(STRING).description("결과 코드"),
-					fieldWithPath("message").type(STRING).description("결과 메시지"),
-					fieldWithPath("data[].id").type(NUMBER).description("회고록 아이디"),
-					fieldWithPath("data[].content").type(STRING).description("회고록 내용"),
-					fieldWithPath("data[].createDate").type(STRING).description("회고 등록 날짜"),
-					fieldWithPath("data[].updateDate").type(STRING).description("회고 수정 마감 날짜")
+					beneathPath("data").withSubsectionId("data"),
+					fieldWithPath("id").type(NUMBER).description("답글 아이디"),
+					fieldWithPath("content").type(STRING).description("답글 내용"),
+					fieldWithPath("emojis[]").type(ARRAY).description("댓글에 대한 이모지"),
+					fieldWithPath("createDate").type(STRING).description("답글 등록 날짜"),
+					fieldWithPath("updateDate").type(STRING).description("답글 수정 날짜")
 				)));
 	}
 

--- a/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/diary/repository/DiaryRepositoryTest.java
@@ -108,9 +108,9 @@ class DiaryRepositoryTest {
 				.hasFieldOrProperty("id")
 				.hasFieldOrProperty("content");
 			if (previousDate != null) {
-				assertThat(diary.getCreatedAt()).isBeforeOrEqualTo(previousDate);
+				assertThat(diary.getCreateDate()).isBeforeOrEqualTo(previousDate);
 			}
-			previousDate = diary.getCreatedAt();
+			previousDate = diary.getCreateDate();
 		}
 	}
 


### PR DESCRIPTION
# 작업 사항
- #46 

## 오류 내용
### 1. 댓글에 대한 생성날짜 수정날짜가 null 로 반환
![KakaoTalk_Photo_2023-08-20-21-46-08](https://github.com/Clover-Habiters/backend/assets/104195103/31fe329c-de86-4e3c-afc3-1b5ade630d5a)

### 2. 대댓글을 등록 시 테이블에 내용이 정상적으로 등록이 되지 않음. (`parentId` = `null`)
![KakaoTalk_Photo_2023-08-20-21-46-21](https://github.com/Clover-Habiters/backend/assets/104195103/35795179-3466-4bd0-822d-f56546187f4b)


## 작업 내용
[chore : BaseEntity 필드명 수정](https://github.com/Clover-Habiters/backend/commit/2c2d81c2bb6eb123f3049c6276e0d31910306d5f) 
- `createAt` -> `createDate` 로 변경하였습니다.
- DTO 객체와 서로 다른 필드명으로 인하여 코드량이 증가하여 통일하였습니다.
- 기존 `createAt` 을 사용하는 클래스들도 같이 수정하였습니다.

[chore : comment 데이터 매핑 수정](https://github.com/Clover-Habiters/backend/commit/e4c3219821fff852e09efbe1438ad4f17c863663) 
- 게시글로 댓글을 내용과 함께 조회 할 경우 Mapper 가 정상적으로 날짜를 매핑하지 못하는 문제가 발생하였습니다.
- `BaseEntity` 를 수정하여 정상적으로 데이터가 매핑되도록 수정하였습니다.
- 답글을 등록 할 경우도 마찬가지로 변수명이 일치하지않아, 정상적으로 답글이 등록이 안되는 문제가 발생하여 수정하였습니다.
- 댓글의 이모지도 함께 조회 하도록 추가하였습니다.

[chore(Test) : comment 문서화 내용 변경](https://github.com/Clover-Habiters/backend/commit/09863605f7b4fd36ee76fa4554c6a1be20ff9bde) 
- 공통 코드와 메시지를 분리하여 출력하도록 변경하였습니다.
- 이모지에 대한 내용도 함께 문서화 하도록 수정하였습니다.