### PR TITLE
[#46] Refactor : 댓글 API 리팩토링

### DIFF
--- a/src/docs/asciidoc/api/Comment-API.adoc
+++ b/src/docs/asciidoc/api/Comment-API.adoc
@@ -81,6 +81,25 @@ include::{snippets}/comment-controller-test/update-comment-test/response-fields-
 
 include::{snippets}/comment-controller-test/update-comment-test/http-response.adoc[]
 
+=== 댓글 삭제
+
+*endpoint* +
+_/posts/{postId}/comments/{commentId}_
+
+==== Request
+
+include::{snippets}/comment-controller-test/delete-comment-test/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/comment-controller-test/delete-comment-test/http-request.adoc[]
+
+==== Response
+
+===== Response HTTP Example
+
+include::{snippets}/comment-controller-test/delete-comment-test/http-response.adoc[]
+
 === 답글 등록
 
 *endpoint* +

--- a/src/docs/asciidoc/api/Comment-API.adoc
+++ b/src/docs/asciidoc/api/Comment-API.adoc
@@ -19,7 +19,7 @@ include::{snippets}/habit-controller-test/create-habit-test/request-headers.adoc
 === 댓글 등록
 
 *endpoint* +
-_/posts/{postId}/comment_
+_/posts/{postId}/comments_
 
 ==== Request
 
@@ -32,16 +32,37 @@ include::{snippets}/comment-controller-test/create-comment-test/http-request.ado
 
 ==== Response
 
-include::{snippets}/comment-controller-test/create-comment-test/response-fields.adoc[]
+include::{snippets}/comment-controller-test/create-comment-test/response-fields-data.adoc[]
 
 ===== Response HTTP Example
 
 include::{snippets}/comment-controller-test/create-comment-test/http-response.adoc[]
 
+=== 댓글 조회
+
+*endpoint* +
+_/posts/{postId}/comments_
+
+==== Request
+
+include::{snippets}/comment-controller-test/get-comment-list-test/path-parameters.adoc[]
+
+===== Request HTTP Example
+
+include::{snippets}/comment-controller-test/get-comment-list-test/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/comment-controller-test/get-comment-list-test/response-fields-data.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/comment-controller-test/get-comment-list-test/http-response.adoc[]
+
 === 댓글 수정
 
 *endpoint* +
-_/posts/{postId}/{commentId}_
+_/posts/{postId}/comments/{commentId}_
 
 ==== Request
 
@@ -54,7 +75,7 @@ include::{snippets}/comment-controller-test/update-comment-test/http-request.ado
 
 ==== Response
 
-include::{snippets}/comment-controller-test/update-comment-test/response-fields.adoc[]
+include::{snippets}/comment-controller-test/update-comment-test/response-fields-data.adoc[]
 
 ===== Response HTTP Example
 
@@ -63,7 +84,7 @@ include::{snippets}/comment-controller-test/update-comment-test/http-response.ad
 === 답글 등록
 
 *endpoint* +
-_/posts/{postId}/{commentId}/reply_
+_/posts/{postId}/comments/{commentId}/reply_
 
 ==== Request
 
@@ -84,7 +105,7 @@ include::{snippets}/comment-controller-test/create-reply-test/http-response.adoc
 === 답글 조회
 
 *endpoint* +
-_/posts/{postId}/{commentId}/reply_
+_/posts/{postId}/comments/{commentId}/reply_
 
 ==== Request
 

--- a/src/main/java/com/clover/habbittracker/domain/comment/api/CommentController.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/api/CommentController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.*;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,6 +46,17 @@ public class CommentController {
 	) {
 		List<CommentResponse> commentList = commentService.getCommentsOf(postId);
 		return ApiResponse.success(commentList);
+	}
+
+	@DeleteMapping("/{commentId}")
+	@ResponseStatus(NO_CONTENT)
+	public ApiResponse<Void> deleteComment(
+		@AuthenticationPrincipal Long memberId,
+		@PathVariable Long postId,
+		@PathVariable Long commentId
+	) {
+		commentService.deleteComment(memberId, commentId, postId);
+		return ApiResponse.success();
 	}
 
 	@PutMapping("/{commentId}")

--- a/src/main/java/com/clover/habbittracker/domain/comment/api/CommentController.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/api/CommentController.java
@@ -23,12 +23,12 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/posts")
+@RequestMapping("/posts/{postId}/comments")
 public class CommentController {
 
 	private final CommentService commentService;
 
-	@PostMapping("/{postId}/comment")
+	@PostMapping
 	@ResponseStatus(CREATED)
 	public ApiResponse<CommentResponse> createComment(
 		@AuthenticationPrincipal Long memberId,
@@ -39,7 +39,15 @@ public class CommentController {
 		return ApiResponse.success(comment);
 	}
 
-	@PutMapping("/{postId}/comment/{commentId}")
+	@GetMapping
+	public ApiResponse<List<CommentResponse>> getCommentList(
+		@PathVariable Long postId
+	) {
+		List<CommentResponse> commentList = commentService.getCommentsOf(postId);
+		return ApiResponse.success(commentList);
+	}
+
+	@PutMapping("/{commentId}")
 	public ApiResponse<CommentResponse> updateComment(
 		@AuthenticationPrincipal Long memberId,
 		@PathVariable Long commentId,
@@ -50,7 +58,7 @@ public class CommentController {
 		return ApiResponse.success(updateComment);
 	}
 
-	@GetMapping("/{postId}/comment/{commentId}/reply")
+	@GetMapping("/{commentId}/reply")
 	public ApiResponse<List<CommentResponse>> getReplyList(
 		@PathVariable Long postId,
 		@PathVariable Long commentId
@@ -59,7 +67,7 @@ public class CommentController {
 		return ApiResponse.success(replyList);
 	}
 
-	@PostMapping("/{postId}/comment/{commentId}/reply")
+	@PostMapping("/{commentId}/reply")
 	@ResponseStatus(CREATED)
 	public ApiResponse<Void> createReply(
 		@AuthenticationPrincipal Long memberId,

--- a/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/dto/CommentResponse.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public record CommentResponse(
 	Long id,
 	String content,
-
+	Long authorId,
 	List<EmojiResponse> emojis,
 	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	LocalDateTime createDate,

--- a/src/main/java/com/clover/habbittracker/domain/comment/entity/Comment.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/entity/Comment.java
@@ -39,7 +39,6 @@ public class Comment extends BaseEntity {
 
 	@OneToMany
 	@JoinColumn(name = "domainId")
-	@BatchSize(size = 100)
 	private final List<Emoji> emojis = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/clover/habbittracker/domain/comment/entity/Comment.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/entity/Comment.java
@@ -6,6 +6,7 @@ import static lombok.AccessLevel.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -16,6 +17,7 @@ import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.global.base.entity.BaseEntity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -37,6 +39,7 @@ public class Comment extends BaseEntity {
 
 	@OneToMany
 	@JoinColumn(name = "domainId")
+	@BatchSize(size = 100)
 	private final List<Emoji> emojis = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,7 +48,7 @@ public class Comment extends BaseEntity {
 	@ManyToOne
 	@JoinColumn(name = "memberId")
 	private Member member;
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "postId")
 	private Post post;
 	private Long parentId;

--- a/src/main/java/com/clover/habbittracker/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/mapper/CommentMapper.java
@@ -20,11 +20,13 @@ public interface CommentMapper {
 		@Mapping(source = "member", target = "member")
 	})
 	Comment toComment(CommentRequest request, Member member, Post post);
+
 	@Mappings({
 		@Mapping(source = "request.content", target = "content"),
 		@Mapping(source = "member", target = "member")
 	})
 	Comment toReply(CommentRequest request, Member member, Post post, Long parentId);
 
+	@Mapping(source = "comment.member.id", target = "authorId")
 	CommentResponse toCommentResponse(Comment comment);
 }

--- a/src/main/java/com/clover/habbittracker/domain/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/repository/CommentCustomRepository.java
@@ -10,4 +10,6 @@ public interface CommentCustomRepository {
 	Optional<Comment> findByIdAndPostId(Long commentId, Long postId);
 
 	List<Comment> findChildCommentById(Long commentId);
+
+	List<Comment> findByPostId(Long postId);
 }

--- a/src/main/java/com/clover/habbittracker/domain/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/repository/CommentCustomRepositoryImpl.java
@@ -10,15 +10,17 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class CommentCustomRepositoryImpl implements CommentCustomRepository{
+public class CommentCustomRepositoryImpl implements CommentCustomRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
+
 	@Override
 	public Optional<Comment> findByIdAndPostId(Long commentId, Long postId) {
 
@@ -32,6 +34,24 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository{
 			.fetchOne();
 
 		return Optional.ofNullable(result);
+	}
+
+	@Override
+	public List<Comment> findByPostId(Long postId) {
+		return jpaQueryFactory
+			.selectFrom(comment)
+			.leftJoin(comment.member, member)
+			.fetchJoin()
+			.where(eqPost(postId).and(NotReply()))
+			.fetch();
+	}
+
+	private BooleanExpression NotReply() {
+		return comment.parentId.isNull();
+	}
+
+	private BooleanExpression eqPost(Long postId) {
+		return comment.post.id.eq(postId);
 	}
 
 	@Override

--- a/src/main/java/com/clover/habbittracker/domain/comment/service/CommentService.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/service/CommentService.java
@@ -7,13 +7,14 @@ import com.clover.habbittracker.domain.comment.dto.CommentResponse;
 
 public interface CommentService {
 
-
 	CommentResponse createComment(Long memberId, Long postId, CommentRequest request);
 
+	List<CommentResponse> getCommentsOf(Long postId);
 
 	CommentResponse updateComment(Long memberId, Long commentId, Long postId, CommentRequest request);
 
 	List<CommentResponse> getReplyList(Long commentId, Long postId);
 
 	void createReply(Long memberId, Long commentId, Long postId, CommentRequest request);
+
 }

--- a/src/main/java/com/clover/habbittracker/domain/comment/service/CommentService.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/service/CommentService.java
@@ -17,4 +17,5 @@ public interface CommentService {
 
 	void createReply(Long memberId, Long commentId, Long postId, CommentRequest request);
 
+	void deleteComment(Long memberId, Long commentId, Long postId);
 }

--- a/src/main/java/com/clover/habbittracker/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/service/CommentServiceImpl.java
@@ -43,6 +43,12 @@ public class CommentServiceImpl implements CommentService {
 	}
 
 	@Override
+	public List<CommentResponse> getCommentsOf(Long postId) {
+		List<Comment> commentList = commentRepository.findByPostId(postId);
+		return commentList.stream().map(commentMapper::toCommentResponse).toList();
+	}
+
+	@Override
 	@Transactional
 	public CommentResponse updateComment(Long memberId, Long commentId, Long postId, CommentRequest request) {
 		Comment comment = commentRepository.findByIdAndPostId(commentId, postId)

--- a/src/main/java/com/clover/habbittracker/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/comment/service/CommentServiceImpl.java
@@ -49,6 +49,14 @@ public class CommentServiceImpl implements CommentService {
 	}
 
 	@Override
+	public void deleteComment(Long memberId, Long commentId, Long postId) {
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new IllegalArgumentException("NotFoundComment"));
+		verifyPermissions(comment.getMember(), memberId);
+		commentRepository.delete(comment);
+	}
+
+	@Override
 	@Transactional
 	public CommentResponse updateComment(Long memberId, Long commentId, Long postId, CommentRequest request) {
 		Comment comment = commentRepository.findByIdAndPostId(commentId, postId)

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostDetailResponse.java
@@ -5,7 +5,6 @@ import static com.fasterxml.jackson.annotation.JsonFormat.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.clover.habbittracker.domain.comment.dto.CommentResponse;
 import com.clover.habbittracker.domain.emoji.entity.Emoji;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -16,7 +15,6 @@ public record PostDetailResponse(
 	String content,
 	Post.Category category,
 	Long views,
-	List<CommentResponse> comments,
 	List<Emoji> emojis,
 	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
 	LocalDateTime createDate,

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
 
 public record PostResponse(
 	Long id,
@@ -19,4 +20,7 @@ public record PostResponse(
 	@JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
 	LocalDateTime createDate
 ) {
+	@QueryProjection
+	public PostResponse {
+	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -43,7 +43,6 @@ public class Post extends BaseEntity {
 		cascade = CascadeType.REMOVE,
 		orphanRemoval = true,
 		fetch = FetchType.LAZY)
-	@BatchSize(size = 100)
 	private final List<Comment> comments = new ArrayList<>();
 	@OneToMany
 	@JoinColumn(name = "domainId")

--- a/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/entity/Post.java
@@ -43,11 +43,10 @@ public class Post extends BaseEntity {
 		cascade = CascadeType.REMOVE,
 		orphanRemoval = true,
 		fetch = FetchType.LAZY)
-	@BatchSize(size = 50)
+	@BatchSize(size = 100)
 	private final List<Comment> comments = new ArrayList<>();
 	@OneToMany
 	@JoinColumn(name = "domainId")
-	@BatchSize(size = 50)
 	private final List<Emoji> emojis = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/clover/habbittracker/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/mapper/PostMapper.java
@@ -2,19 +2,12 @@ package com.clover.habbittracker.domain.post.mapper;
 
 import static org.mapstruct.ReportingPolicy.*;
 
-import java.util.List;
-
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
-import org.mapstruct.Named;
 
-import com.clover.habbittracker.domain.comment.entity.Comment;
-import com.clover.habbittracker.domain.emoji.entity.Emoji;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
-import com.clover.habbittracker.domain.post.dto.PostResponse;
 import com.clover.habbittracker.domain.post.entity.Post;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = IGNORE)
@@ -22,22 +15,6 @@ public interface PostMapper {
 
 	Post toPost(PostRequest request, Member member);
 
-	@Mappings({
-		@Mapping(source = "post.comments", target = "numOfComments", qualifiedByName = "commentsToSize"),
-		@Mapping(source = "post.emojis", target = "numOfEmojis", qualifiedByName = "emojisToSize"),
-	})
-	PostResponse toPostResponse(Post post);
-
 	@Mapping(source = "post.member.id", target = "memberId")
 	PostDetailResponse toPostDetail(Post post);
-
-	@Named("commentsToSize")
-	static Integer commentsToSize(List<Comment> comments) {
-		return comments.size();
-	}
-
-	@Named("emojisToSize")
-	static Integer emojisToSize(List<Emoji> emojis) {
-		return emojis.size();
-	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
@@ -3,6 +3,7 @@ package com.clover.habbittracker.domain.post.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.clover.habbittracker.domain.post.dto.PostResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
@@ -11,11 +12,11 @@ import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
 import com.clover.habbittracker.domain.post.entity.Post;
 
 public interface PostCustomRepository {
-	List<Post> findAllPostsSummary(Pageable pageable, Post.Category category);
+	List<PostResponse> findAllPostsSummary(Pageable pageable, Post.Category category);
 
 	Optional<Post> joinMemberAndEmojisFindById(@Param("postId") Long postId);
 
 	Long updateViews(Long postId);
 
-	Page<Post> searchPostBy(PostSearchCondition postSearchCondition, Pageable pageable);
+	Page<PostResponse> searchPostBy(PostSearchCondition postSearchCondition, Pageable pageable);
 }

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepository.java
@@ -13,7 +13,7 @@ import com.clover.habbittracker.domain.post.entity.Post;
 public interface PostCustomRepository {
 	List<Post> findAllPostsSummary(Pageable pageable, Post.Category category);
 
-	Optional<Post> joinMemberAndCommentFindById(@Param("postId") Long postId);
+	Optional<Post> joinMemberAndEmojisFindById(@Param("postId") Long postId);
 
 	Long updateViews(Long postId);
 

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.clover.habbittracker.domain.post.repository;
 
-import static com.clover.habbittracker.domain.comment.entity.QComment.*;
+import static com.clover.habbittracker.domain.emoji.entity.QEmoji.*;
 import static com.clover.habbittracker.domain.member.entity.QMember.*;
 import static com.clover.habbittracker.domain.post.dto.PostSearchCondition.SearchType.*;
 import static com.clover.habbittracker.domain.post.entity.QPost.*;
@@ -35,7 +35,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 	public List<Post> findAllPostsSummary(Pageable pageable, Post.Category category) {
 
 		return jpaQueryFactory.selectFrom(post)
-			.leftJoin(post.member, member).fetchJoin()
+			.leftJoin(post.member, member)
+			.fetchJoin()
 			.where(eqCategory(category))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
@@ -44,11 +45,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 	}
 
 	@Override
-	public Optional<Post> joinMemberAndCommentFindById(Long postId) {
+	public Optional<Post> joinMemberAndEmojisFindById(Long postId) {
 		Post result = jpaQueryFactory.selectFrom(post)
 			.leftJoin(post.member, member)
 			.fetchJoin()
-			.leftJoin(post.comments, comment)
+			.leftJoin(post.emojis, emoji)
 			.fetchJoin()
 			.where(eqId(postId))
 			.fetchOne();

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
@@ -13,7 +13,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import com.clover.habbittracker.domain.post.dto.PostResponse;
 import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
+import com.clover.habbittracker.domain.post.dto.QPostResponse;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -32,12 +34,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
-	public List<Post> findAllPostsSummary(Pageable pageable, Post.Category category) {
+	public List<PostResponse> findAllPostsSummary(Pageable pageable, Post.Category category) {
 
-		return jpaQueryFactory.selectFrom(post)
-			.leftJoin(post.member, member)
-			.fetchJoin()
-			.where(eqCategory(category))
+		return jpaQueryFactory
+			.select(QPostResponse())
+			.from(post)
+			.where(eqFilter(category))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.orderBy(post.createDate.desc())
@@ -65,10 +67,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 	}
 
 	@Override
-	public Page<Post> searchPostBy(PostSearchCondition postSearchCondition, Pageable pageable) {
+	public Page<PostResponse> searchPostBy(PostSearchCondition postSearchCondition, Pageable pageable) {
 
-		List<Post> content = jpaQueryFactory.selectFrom(post)
-			.leftJoin(post.member, member).fetchJoin()
+		List<PostResponse> content = jpaQueryFactory
+			.select(QPostResponse())
+			.from(post)
 			.where(
 				eqFilter(postSearchCondition.getCategory()),
 				matchKeyword(postSearchCondition.getSearchType(), postSearchCondition.getKeyword())
@@ -91,13 +94,6 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 		return null;
 	}
 
-	private BooleanExpression eqCategory(Post.Category category) {
-		if (category != null) {
-			return post.category.eq(category);
-		}
-		return null;
-	}
-
 	private BooleanExpression eqFilter(Post.Category category) {
 		if (category == null || Post.Category.ALL.equals(category)) {
 			return null;
@@ -109,6 +105,19 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 		return jpaQueryFactory.select(post.count())
 			.from(post)
 			.fetch().size();
+	}
+
+	private QPostResponse QPostResponse() {
+		return new QPostResponse(
+			post.id,
+			post.title,
+			post.content,
+			post.thumbnailUrl,
+			post.category,
+			post.views,
+			post.comments.size(),
+			post.emojis.size(),
+			post.createDate);
 	}
 
 	private BooleanExpression matchKeyword(PostSearchCondition.SearchType searchType, String keyword) {

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -45,7 +45,7 @@ public class PostServiceImpl implements PostService {
 	@Override
 	@Transactional
 	public PostDetailResponse getPostBy(Long postId) {
-		Post post = postRepository.joinMemberAndCommentFindById(postId)
+		Post post = postRepository.joinMemberAndEmojisFindById(postId)
 			.orElseThrow(() -> new PostNotFoundException(postId));
 		postRepository.updateViews(post.getId());
 		return postMapper.toPostDetail(post);
@@ -69,7 +69,7 @@ public class PostServiceImpl implements PostService {
 	@Override
 	@Transactional
 	public Long updatePost(Long postId, PostRequest request, Long memberId) {
-		Post post = postRepository.joinMemberAndCommentFindById(postId)
+		Post post = postRepository.joinMemberAndEmojisFindById(postId)
 			.orElseThrow(() -> new PostNotFoundException(postId));
 		verifyPermissions(post.getMember(), memberId);
 		post.updatePost(request);
@@ -79,7 +79,7 @@ public class PostServiceImpl implements PostService {
 	@Override
 	@Transactional
 	public void deletePost(Long postId, Long memberId) {
-		Post post = postRepository.joinMemberAndCommentFindById(postId)
+		Post post = postRepository.joinMemberAndEmojisFindById(postId)
 			.orElseThrow(() -> new PostNotFoundException(postId));
 		verifyPermissions(post.getMember(), memberId);
 		postRepository.deleteById(postId);

--- a/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/service/PostServiceImpl.java
@@ -3,6 +3,7 @@ package com.clover.habbittracker.domain.post.service;
 import java.util.List;
 import java.util.Objects;
 
+import com.clover.habbittracker.domain.post.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -11,10 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.exception.MemberNotFoundException;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
-import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
-import com.clover.habbittracker.domain.post.dto.PostRequest;
-import com.clover.habbittracker.domain.post.dto.PostResponse;
-import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.domain.post.exception.PostNotFoundException;
 import com.clover.habbittracker.domain.post.mapper.PostMapper;
@@ -54,16 +51,12 @@ public class PostServiceImpl implements PostService {
 
 	@Override
 	public Page<PostResponse> getPostBy(PostSearchCondition postSearchCondition, Pageable pageable) {
-
-		Page<Post> searchedPost = postRepository.searchPostBy(postSearchCondition, pageable);
-
-		return searchedPost.map(postMapper::toPostResponse);
+		return postRepository.searchPostBy(postSearchCondition, pageable);
 	}
 
 	@Override
 	public List<PostResponse> getPostAllBy(Post.Category category, Pageable pageable) {
-		List<Post> postsSummary = postRepository.findAllPostsSummary(pageable, category);
-		return postsSummary.stream().map(postMapper::toPostResponse).toList();
+		return postRepository.findAllPostsSummary(pageable, category);
 	}
 
 	@Override

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -11,6 +11,7 @@ spring:
     properties:
       hibernate:
         dialect: com.clover.habbittracker.global.config.db.MySQLConfig$MySQLCustomDialect
+        default_batch_fetch_size: 100
 
   # redis
   data:

--- a/src/test/java/com/clover/habbittracker/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/comment/api/CommentControllerTest.java
@@ -49,7 +49,7 @@ class CommentControllerTest extends RestDocsSupport {
 		//when then
 		mockMvc.perform(
 				RestDocumentationRequestBuilders
-					.post("/posts/{postId}/comment", savePost.getId())
+					.post("/posts/{postId}/comments", savePost.getId())
 					.header("Authorization", "Bearer " + accessToken)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -71,7 +71,42 @@ class CommentControllerTest extends RestDocsSupport {
 					beneathPath("data").withSubsectionId("data"),
 					fieldWithPath("id").type(NUMBER).description("생성된 댓글 아이디"),
 					fieldWithPath("content").type(STRING).description("생성된 댓글 내용"),
+					fieldWithPath("authorId").type(NUMBER).description("댓글 작성자"),
 					fieldWithPath("emojis[]").type(ARRAY).description("댓글에 대한 이모지"),
+					fieldWithPath("createDate").type(STRING).description("댓글 생성 날짜"),
+					fieldWithPath("updateDate").type(STRING).description("댓글 최근 수정 날짜")
+				)));
+	}
+
+	@Test
+	@DisplayName("사용자는 게시글의 댓글을 조회 할 수 있다.")
+	void getCommentListTest() throws Exception {
+		//given
+		Comment comment = Comment.builder()
+			.member(savedMember)
+			.content("testComment")
+			.post(savePost)
+			.build();
+		Comment savedComment = commentRepository.save(comment);
+
+		//when then
+		mockMvc.perform(RestDocumentationRequestBuilders
+				.get("/posts/{postId}/comments", savePost.getId())
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andDo(restDocs.document(
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				pathParameters(
+					parameterWithName("postId").description("게시글 id")
+				),
+				responseFields(
+					beneathPath("data").withSubsectionId("data"),
+					fieldWithPath("id").type(NUMBER).description("댓글 아이디"),
+					fieldWithPath("content").type(STRING).description("댓글 내용"),
+					fieldWithPath("authorId").type(NUMBER).description("댓글 작성자"),
+					fieldWithPath("emojis[]").type(ARRAY).description("댓글의 이모지"),
 					fieldWithPath("createDate").type(STRING).description("댓글 생성 날짜"),
 					fieldWithPath("updateDate").type(STRING).description("댓글 최근 수정 날짜")
 				)));
@@ -92,7 +127,7 @@ class CommentControllerTest extends RestDocsSupport {
 		//when then
 		mockMvc.perform(
 				RestDocumentationRequestBuilders
-					.put("/posts/{postId}/comment/{commentId}", savePost.getId(), savedComment.getId())
+					.put("/posts/{postId}/comments/{commentId}", savePost.getId(), savedComment.getId())
 					.header("Authorization", "Bearer " + accessToken)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -112,8 +147,9 @@ class CommentControllerTest extends RestDocsSupport {
 				),
 				responseFields(
 					beneathPath("data").withSubsectionId("data"),
-					fieldWithPath("id").type(NUMBER).description("생성된 댓글 아이디"),
-					fieldWithPath("content").type(STRING).description("생성된 댓글 내용"),
+					fieldWithPath("id").type(NUMBER).description("수정한 댓글 아이디"),
+					fieldWithPath("content").type(STRING).description("수정된 댓글 내용"),
+					fieldWithPath("authorId").type(NUMBER).description("댓글 작성자"),
 					fieldWithPath("emojis[]").type(ARRAY).description("댓글의 이모지"),
 					fieldWithPath("createDate").type(STRING).description("댓글 생성 날짜"),
 					fieldWithPath("updateDate").type(STRING).description("댓글 최근 수정 날짜")
@@ -124,7 +160,7 @@ class CommentControllerTest extends RestDocsSupport {
 	@DisplayName("사용자는 댓글의 답글을 작성 할 수 있다.")
 	void createReplyTest() throws Exception {
 		//given
-		CommentRequest commentRequest = new CommentRequest("updateComment");
+		CommentRequest commentRequest = new CommentRequest("testReply");
 		String request = new ObjectMapper().writeValueAsString(commentRequest);
 		Comment comment = Comment.builder()
 			.member(savedMember)
@@ -136,7 +172,7 @@ class CommentControllerTest extends RestDocsSupport {
 		//when then
 		mockMvc.perform(
 				RestDocumentationRequestBuilders
-					.post("/posts/{postId}/comment/{commentId}/reply", savePost.getId(), savedComment.getId())
+					.post("/posts/{postId}/comments/{commentId}/reply", savePost.getId(), savedComment.getId())
 					.header("Authorization", "Bearer " + accessToken)
 					.contentType(APPLICATION_JSON)
 					.content(request))
@@ -179,10 +215,8 @@ class CommentControllerTest extends RestDocsSupport {
 		//when then
 		mockMvc.perform(
 				RestDocumentationRequestBuilders
-					.get("/posts/{postId}/comment/{commentId}/reply", savePost.getId(), savedComment.getId())
-					.header("Authorization", "Bearer " + accessToken)
-					.contentType(APPLICATION_JSON)
-					.content(request))
+					.get("/posts/{postId}/comments/{commentId}/reply", savePost.getId(), savedComment.getId())
+					.header("Authorization", "Bearer " + accessToken))
 			.andExpect(status().isOk())
 			.andDo(restDocs.document(
 				requestHeaders(
@@ -196,6 +230,7 @@ class CommentControllerTest extends RestDocsSupport {
 					beneathPath("data").withSubsectionId("data"),
 					fieldWithPath("id").type(NUMBER).description("답글 아이디"),
 					fieldWithPath("content").type(STRING).description("답글 내용"),
+					fieldWithPath("authorId").type(NUMBER).description("답글 작성자"),
 					fieldWithPath("emojis[]").type(ARRAY).description("댓글에 대한 이모지"),
 					fieldWithPath("createDate").type(STRING).description("답글 등록 날짜"),
 					fieldWithPath("updateDate").type(STRING).description("답글 수정 날짜")

--- a/src/test/java/com/clover/habbittracker/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/api/PostControllerTest.java
@@ -140,7 +140,6 @@ class PostControllerTest extends RestDocsSupport {
 					fieldWithPath("content").type(STRING).description("게시글 본문"),
 					fieldWithPath("category").type(STRING).description(generateLinkCode(DocUrl.CATEGORY)),
 					fieldWithPath("views").type(NUMBER).description("조회수"),
-					fieldWithPath("comments").type(ARRAY).description("댓글 수"),
 					fieldWithPath("emojis").type(ARRAY).description("이모지 수"),
 					fieldWithPath("createDate").type(STRING).description("생성 날짜"),
 					fieldWithPath("updateDate").type(STRING).description("수정 날짜")

--- a/src/test/java/com/clover/habbittracker/domain/post/mapper/PostMapperTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/mapper/PostMapperTest.java
@@ -17,7 +17,6 @@ import com.clover.habbittracker.domain.comment.mapper.CommentMapperImpl;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.post.dto.PostDetailResponse;
 import com.clover.habbittracker.domain.post.dto.PostRequest;
-import com.clover.habbittracker.domain.post.dto.PostResponse;
 import com.clover.habbittracker.domain.post.entity.Post;
 
 public class PostMapperTest {
@@ -50,26 +49,6 @@ public class PostMapperTest {
 	}
 
 	@Test
-	@DisplayName("Post 를 PostResponse 로 매핑 시킬 수 있다.")
-	void toPostResponseTest() {
-
-		//given & when
-		PostResponse postResponse = postMapper.toPostResponse(testPost);
-
-		//then
-		assertAll(() -> {
-			assertThat(testPost.getId()).isEqualTo(postResponse.id());
-			assertThat(testPost.getTitle()).isEqualTo(postResponse.title());
-			assertThat(testPost.getContent()).isEqualTo(postResponse.content());
-			assertThat(testPost.getCategory()).isEqualTo(postResponse.category());
-			assertThat(testPost.getViews()).isEqualTo(postResponse.views());
-			assertThat(testPost.getEmojis().size()).isEqualTo(postResponse.numOfEmojis());
-			assertThat(testPost.getComments().size()).isEqualTo(postResponse.numOfComments());
-		});
-
-	}
-
-	@Test
 	@DisplayName("Post 를 PostDetailResponse 로 매핑 시킬 수 있다.")
 	void toPostDetailResponseTest() {
 		//given
@@ -90,7 +69,6 @@ public class PostMapperTest {
 			assertThat(testPost.getCategory()).isEqualTo(postDetailResponse.category());
 			assertThat(testPost.getViews()).isEqualTo(postDetailResponse.views());
 			assertThat(testPost.getEmojis()).isEqualTo(postDetailResponse.emojis());
-			assertThat(comments).isEqualTo(postDetailResponse.comments());
 		});
 	}
 }

--- a/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
@@ -106,7 +106,6 @@ public class PostRepositoryTest {
 			assertThat(postResponse.category()).isEqualTo(savedPost.getCategory());
 			assertThat(postResponse.thumbnailUrl()).isEqualTo(savedPost.getThumbnailUrl());
 			assertThat(postResponse.views()).isEqualTo(0);
-			assertThat(postResponse.createDate()).isEqualTo(savedPost.getCreateDate());
 		});
 	}
 

--- a/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
@@ -10,7 +10,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.clover.habbittracker.util.CustomTransaction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -22,16 +21,17 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
 
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
 import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.global.config.db.JpaConfig;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.TransactionStatus;
+import com.clover.habbittracker.util.CustomTransaction;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -90,7 +90,7 @@ public class PostRepositoryTest {
 		Post savePost = postRepository.save(testPost);
 
 		//when
-		Optional<Post> findPost = postRepository.joinMemberAndCommentFindById(savePost.getId());
+		Optional<Post> findPost = postRepository.joinMemberAndEmojisFindById(savePost.getId());
 
 		//then
 		assertThat(findPost).isPresent();
@@ -149,7 +149,7 @@ public class PostRepositoryTest {
 		Post save = postRepository.save(post);
 		transactionManager.commit(status);
 		PostSearchCondition searchCondition = new PostSearchCondition(save.getCategory(),
-				PostSearchCondition.SearchType.CONTENT, save.getContent());
+			PostSearchCondition.SearchType.CONTENT, save.getContent());
 		//when
 		Page<Post> posts = postRepository.searchPostBy(searchCondition, pageable);
 

--- a/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/repository/PostRepositoryTest.java
@@ -3,6 +3,7 @@ package com.clover.habbittracker.domain.post.repository;
 import static com.clover.habbittracker.util.MemberProvider.*;
 import static com.clover.habbittracker.util.PostProvider.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,12 +27,19 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 
+import com.clover.habbittracker.domain.comment.entity.Comment;
+import com.clover.habbittracker.domain.comment.repository.CommentRepository;
+import com.clover.habbittracker.domain.emoji.entity.Emoji;
+import com.clover.habbittracker.domain.emoji.repository.EmojiRepository;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.domain.member.repository.MemberRepository;
+import com.clover.habbittracker.domain.post.dto.PostResponse;
 import com.clover.habbittracker.domain.post.dto.PostSearchCondition;
 import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.global.config.db.JpaConfig;
 import com.clover.habbittracker.util.CustomTransaction;
+import com.clover.habbittracker.util.EmojiProvider;
+import com.clover.habbittracker.util.PostProvider;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -43,6 +51,12 @@ public class PostRepositoryTest {
 
 	@Autowired
 	private MemberRepository memberRepository;
+
+	@Autowired
+	private EmojiRepository emojiRepository;
+
+	@Autowired
+	private CommentRepository commentRepository;
 
 	@Autowired
 	private PlatformTransactionManager transactionManager;
@@ -68,22 +82,52 @@ public class PostRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("게시글을 페이징 처리하여 조회 할 수 있다.")
-	void findAllPostsSummary() {
+	@DisplayName("게시글 리스트를 조회 할 경우 댓글 및 이모지의 총 개수와 게시글의 요약된 정보를 조회 할 수 있다.")
+	void findAllPostsSummaryTest() {
 		//given
-		for (int i = 0; i < 50; i++) {
+		Post testPost = PostProvider.createTestPost(testMember);
+		Post savedPost = postRepository.save(testPost);
+		Emoji testEmojiInPost = EmojiProvider.createTestEmojiInPost(testMember, savedPost);
+		emojiRepository.save(testEmojiInPost);
+		Comment comment = Comment.builder().post(savedPost).member(testMember).content("댓글").build();
+		commentRepository.save(comment);
+
+		//when
+		List<PostResponse> allPostsSummary = postRepository.findAllPostsSummary(pageable, null);
+
+		//then
+		PostResponse postResponse = allPostsSummary.get(0);
+		assertThat(postResponse.numOfComments()).isEqualTo(1);
+		assertThat(postResponse.numOfEmojis()).isEqualTo(1);
+		assertAll(() -> {
+			assertThat(postResponse.id()).isEqualTo(savedPost.getId());
+			assertThat(postResponse.title()).isEqualTo(savedPost.getTitle());
+			assertThat(postResponse.content()).isEqualTo(savedPost.getContent());
+			assertThat(postResponse.category()).isEqualTo(savedPost.getCategory());
+			assertThat(postResponse.thumbnailUrl()).isEqualTo(savedPost.getThumbnailUrl());
+			assertThat(postResponse.views()).isEqualTo(0);
+			assertThat(postResponse.createDate()).isEqualTo(savedPost.getCreateDate());
+		});
+	}
+
+	@Test
+	@DisplayName("게시글 리스트를 페이징 처리하여 조회 할 수 있다.")
+	void pagingPostsSummaryTest() {
+		//given
+		for (int i = 0; i < 15; i++) {
 			Post testPost = createTestPost(testMember);
 			postRepository.save(testPost);
 		}
 		//when
-		List<Post> postsSummary = postRepository.findAllPostsSummary(pageable, null);
+		List<PostResponse> page01 = postRepository.findAllPostsSummary(pageable, null);
+		List<PostResponse> page02 = postRepository.findAllPostsSummary(PageRequest.of(1, 15), null);
+		assertThat(page01.size()).isEqualTo(15);
+		assertThat(page02.size()).isEqualTo(0);
 
-		//then
-		assertThat(postsSummary.size()).isEqualTo(15);
 	}
 
 	@Test
-	@DisplayName("게시글 Id 로 게시글의 등록자, 댓글을 모두 포함 하여 조회 할 수 있다.")
+	@DisplayName("게시글 Id 로 게시글을 상세 조회 할 수 있다.")
 	void joinCommentAndLikeFindById() {
 		//given
 		Post testPost = createTestPost(testMember);
@@ -107,11 +151,11 @@ public class PostRepositoryTest {
 		Post savePostETC = postRepository.save(postETC);
 
 		//when
-		List<Post> dailyPostsSummary = postRepository.findAllPostsSummary(pageable, Post.Category.DAILY);
+		List<PostResponse> dailyPostsSummary = postRepository.findAllPostsSummary(pageable, Post.Category.DAILY);
 
 		//then
 		assertThat(dailyPostsSummary.size()).isEqualTo(1);
-		assertThat(dailyPostsSummary.get(0)).usingRecursiveComparison().isEqualTo(savePostDaily);
+		assertThat(dailyPostsSummary.get(0).category()).isEqualTo(savePostDaily.getCategory());
 	}
 
 	@Disabled // TODO: 조회수 개선 이후 테스트 진행. 현재 정상적으로 테스트가 불가능.
@@ -151,7 +195,7 @@ public class PostRepositoryTest {
 		PostSearchCondition searchCondition = new PostSearchCondition(save.getCategory(),
 			PostSearchCondition.SearchType.CONTENT, save.getContent());
 		//when
-		Page<Post> posts = postRepository.searchPostBy(searchCondition, pageable);
+		Page<PostResponse> posts = postRepository.searchPostBy(searchCondition, pageable);
 
 		//then
 		assertThat(posts.getContent().size()).isEqualTo(1);

--- a/src/test/java/com/clover/habbittracker/util/CommentProvider.java
+++ b/src/test/java/com/clover/habbittracker/util/CommentProvider.java
@@ -8,6 +8,8 @@ public class CommentProvider {
 
 	private static final String COMMENT_CONTENT = "testContent";
 
+	private static final String REPLY_CONTENT = "testReply";
+
 	private CommentProvider() {
 		/* NO-OP */
 	}
@@ -17,6 +19,15 @@ public class CommentProvider {
 			.content(COMMENT_CONTENT)
 			.member(savedMember)
 			.post(savedPost)
+			.build();
+	}
+
+	public static Comment createTestReply(Member savedMember, Post savedPost, Comment savedComment) {
+		return Comment.builder()
+			.content(REPLY_CONTENT)
+			.member(savedMember)
+			.post(savedPost)
+			.parentId(savedComment.getId())
 			.build();
 	}
 }


### PR DESCRIPTION
# 작업 사항
- #46 

- 기존 댓글 조회는 게시글 상세 조회시 같이 조회 하도록 구성 하였지만, 댓글이 많아짐에 따라 게시글 상세조회 부분이 너무 많은 데이터를 가져오는것 같아 댓글 조회 부분을 분리하여 처리하였습니다!
- 추가로 댓글 삭제 부분이 누락되어 추가하였습니다!

## 작업 내용
[feat : 댓글 조회 API 생성](https://github.com/Clover-Habiters/backend/commit/4a9c7a01f1fbbcf5a5b91f6015e28629af39d083)  

[feat : 댓글 삭제 API 추가](https://github.com/Clover-Habiters/backend/commit/dbf66bc88c5f1256a646c9062ff65bab953cb2db)  

[feat : 댓글 리스트 조회 메서드 추가](https://github.com/Clover-Habiters/backend/commit/7f5d12565e681ecdb1944255479f5d90390f2729)  

[feat : Response 필드 추가](https://github.com/Clover-Habiters/backend/commit/45d55409b9cf81a01c0dee4f820c332f2bbbf770)  

[feat : 댓글 조회 API 문서화 추가](https://github.com/Clover-Habiters/backend/commit/8b846c1ccfc2571d20555842af6288588d17fc66)  

[feat : 댓글 삭제 API 문서화](https://github.com/Clover-Habiters/backend/commit/7149378086627f788c84e9c48c1eea9d25d08b44)  

[feat(Test) : 댓글 조회 테스트 추가](https://github.com/Clover-Habiters/backend/commit/5c6f727eadb2a8c95949b939e987b4d2433fb0bf)  

[feat(Test) : 댓글 테스트 코드 추가](https://github.com/Clover-Habiters/backend/commit/9e9eb158f60c6d4943bef077e271076cc912f83b)  

[feat(Test) : 대댓글 팩터리 메서드 추가](https://github.com/Clover-Habiters/backend/commit/99e9b7975b3c82d58415e220a4297b083d2c7965)  

[chore : 게시글 상세 조회 수정](https://github.com/Clover-Habiters/backend/commit/274d05c3d8dc6d405b15df6818f382b656b62922) 

[chore(Test) : 게시글 조회 시 댓글 검증 삭제](https://github.com/Clover-Habiters/backend/commit/8515ab1ff537d91129247691c48216ce741c9109) 
내용이 많아 커밋 상세 메세지는 제외 하도록 하겠습니다~!

## 작업 외 개선 사항
- 게시글 리스트 조회 시 기존 `fetch Join` 으로 연관된 모든 데이터를 가져와 처리하는 방식에서 dto 로 __값__ 만 가져오도록 수정하였습니다!
- 실제 성능에 차이가 있는지 확인하기 위해 `jmeter`  를 활용하여 성능 테스트를 진행해봤습니다.
![KakaoTalk_Photo_2023-08-24-21-41-32](https://github.com/Clover-Habiters/backend/assets/104195103/4c45c057-0384-4767-b362-1da7d9290200)

- 테스트는 게시글을 15개, 각 게시글당 댓글 10개로 데이터를 준비한 후 100명의 User가 100번 씩 반복하여 테스트를 진행했습니다. 
- 실제로 평균 응답속도와 최소,최대 응답속도가 모두 `70%` 가 줄어들었다는것을 확인 할 수 있었습니다. 특히 최대 응답속도는 `75%` 로 눈에 띄게 성능이 개선되었다고 생각합니다!
- 또한 표준 편차도 응답 속도가 안정적으로 바뀐 점도 확인 할 수 있었습니다!


[refactor : 게시글 조회 쿼리 수정](https://github.com/Clover-Habiters/backend/commit/738386fb300eb4e9dc6f017eb849450f07bdf24d)  
- 현재 게시글 리스트 조회시에는 순수한 `Post` 자체의 조회 보다는 형태를 많이 수정하여 요약된 정보를 조회 하고있다고 생각하여 쿼리문을 수정하였습니다.
- 댓글의 갯수, 이모지의 갯수 등 데이터를 조회 한 후에 처리하는 것이 아닌 DB 자체의 기능을 활용하여 조회 시점에서 `PostResponse` 로 조회 하는것이 더 성능적으로 올바르다고 생각하여 수정하였습니다.

[chore(Test) : PostRepository 테스트 수정](https://github.com/Clover-Habiters/backend/commit/726698256bfd6f5f08672f15b9cef641b60e479e)  
- 테스트 내용이 충분히 검증하도록 테스트 케이스를 추가하였습니다.
- 이모지와 댓글이 게시글 조회 시점에 정상적으로 `count` 여부를 확인하기 위한 테스트를 추가하였습니다.

[chore : PostResponse queryDsl 설정 추가](https://github.com/Clover-Habiters/backend/commit/cbb9ccd7d8a97988f8e0b9acfcdb9bcc0ef65ea8)  
- `@QueryProjection` 을 추가하여 `PostResponse` 도 `QPostResponse` 를 생성 할 수 있도록 추가하였습니다.

## 특이 사항
- 한번에 많은 내용을 작성해서 보기 불편할거같네요...! ㅠㅠㅠ 다음에는 PR을 꼭 나눠서 처리하도록 하겠습니다.!
- 게시글 리스트는 현재 댓글과 이모지의 내용도 함께 포함하여야 하고 다른 형태라고 생각하여 DTO 로 직접 받도록 처리했는데, 성능상에 이점은 확실한거같은데, 성능만을 생각해서 이렇게 해도 되는건지 의문이 들긴합니다! 
- 설정파일에 `default batch size` 를 100 으로 설정하여 코드 내 어노테이션을 제거하였습니다~!