### PR TITLE
[#49] Feat : 사용자 커뮤니티 이용 내역 조회 추가

### DIFF
--- a/src/docs/asciidoc/api/Member-API.adoc
+++ b/src/docs/asciidoc/api/Member-API.adoc
@@ -32,6 +32,22 @@ include::{snippets}/member-controller-test/get-my-profile-test/response-fields.a
 
 include::{snippets}/member-controller-test/get-my-profile-test/http-response.adoc[]
 
+=== 커뮤니티 이용 내역 조회
+
+==== Request
+
+===== Request HTTP Example
+
+include::{snippets}/member-controller-test/get-my-report-test/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member-controller-test/get-my-report-test/response-fields-data.adoc[]
+
+===== Response HTTP Example
+
+include::{snippets}/member-controller-test/get-my-report-test/http-response.adoc[]
+
 === 유저 정보 수정
 
 ==== Request

--- a/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/api/MemberController.java
@@ -12,9 +12,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.clover.habbittracker.domain.member.dto.MemberReportResponse;
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
 import com.clover.habbittracker.domain.member.service.MemberService;
+import com.clover.habbittracker.global.base.dto.ApiResponse;
 import com.clover.habbittracker.global.base.dto.BaseResponse;
 
 import jakarta.validation.Valid;
@@ -47,6 +49,14 @@ public class MemberController {
 		memberService.deleteProfile(memberId);
 		BaseResponse<Void> response = BaseResponse.of(null, MEMBER_DELETE);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
+	}
+
+	@GetMapping("/me/report")
+	ApiResponse<MemberReportResponse> getMyReport(
+		@AuthenticationPrincipal Long memberId
+	) {
+		MemberReportResponse response = memberService.getMyReport(memberId);
+		return ApiResponse.success(response);
 	}
 
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/dto/MemberReportResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/dto/MemberReportResponse.java
@@ -1,0 +1,13 @@
+package com.clover.habbittracker.domain.member.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record MemberReportResponse(
+	int numOfBookmark,
+	int numOfPost,
+	int numOfComment
+) {
+	@QueryProjection
+	public MemberReportResponse {
+	}
+}

--- a/src/main/java/com/clover/habbittracker/domain/member/entity/Member.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/entity/Member.java
@@ -5,8 +5,11 @@ import static jakarta.persistence.GenerationType.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.clover.habbittracker.domain.bookmark.entity.Bookmark;
+import com.clover.habbittracker.domain.comment.entity.Comment;
 import com.clover.habbittracker.domain.diary.entity.Diary;
 import com.clover.habbittracker.domain.habit.entity.Habit;
+import com.clover.habbittracker.domain.post.entity.Post;
 import com.clover.habbittracker.global.base.entity.BaseEntity;
 
 import jakarta.persistence.CascadeType;
@@ -55,6 +58,13 @@ public class Member extends BaseEntity {
 		orphanRemoval = true,
 		fetch = FetchType.LAZY)
 	private final List<Habit> habits = new ArrayList<>();
+
+	@OneToMany(mappedBy = "member")
+	private final List<Post> posts = new ArrayList<>();
+	@OneToMany(mappedBy = "member")
+	private final List<Comment> comments = new ArrayList<>();
+	@OneToMany(mappedBy = "member")
+	private final List<Bookmark> bookmarks = new ArrayList<>();
 
 	public void setProfileImgUrl(String profileImgUrl) {
 		this.profileImgUrl = profileImgUrl;

--- a/src/main/java/com/clover/habbittracker/domain/member/repository/MemberCustomRepository.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/repository/MemberCustomRepository.java
@@ -2,6 +2,7 @@ package com.clover.habbittracker.domain.member.repository;
 
 import java.util.Optional;
 
+import com.clover.habbittracker.domain.member.dto.MemberReportResponse;
 import com.clover.habbittracker.domain.member.entity.Member;
 
 public interface MemberCustomRepository {
@@ -9,4 +10,6 @@ public interface MemberCustomRepository {
 	Optional<Member> findByProviderAndOauthId(String provider, String oauthId);
 
 	Optional<Member> findByNickName(String nickName);
+
+	MemberReportResponse findReportById(Long memberId);
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/repository/MemberCustomRepositoryImpl.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.clover.habbittracker.domain.member.dto.MemberReportResponse;
+import com.clover.habbittracker.domain.member.dto.QMemberReportResponse;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -38,5 +40,20 @@ public class MemberCustomRepositoryImpl implements MemberCustomRepository {
 		return Optional.ofNullable(result);
 	}
 
+	@Override
+	public MemberReportResponse findReportById(Long memberId) {
+		return jpaQueryFactory
+			.select(QMemberReportResponse())
+			.from(member)
+			.where(member.id.eq(memberId))
+			.fetchOne();
+	}
 
+	private QMemberReportResponse QMemberReportResponse() {
+		return new QMemberReportResponse(
+			member.posts.size(),
+			member.comments.size(),
+			member.bookmarks.size()
+		);
+	}
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/service/MemberService.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.clover.habbittracker.domain.member.service;
 
+import com.clover.habbittracker.domain.member.dto.MemberReportResponse;
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
 
@@ -9,4 +10,6 @@ public interface MemberService {
 	MemberResponse updateProfile(Long memberId, MemberRequest request);
 
 	void deleteProfile(Long memberId);
+
+	MemberReportResponse getMyReport(Long memberId);
 }

--- a/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/member/service/MemberServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.clover.habbittracker.domain.member.dto.MemberReportResponse;
 import com.clover.habbittracker.domain.member.dto.MemberRequest;
 import com.clover.habbittracker.domain.member.dto.MemberResponse;
 import com.clover.habbittracker.domain.member.entity.Member;
@@ -42,7 +43,6 @@ public class MemberServiceImpl implements MemberService {
 		memberRepository.deleteById(memberId);
 	}
 
-
 	private Member update(Member member, MemberRequest request) {
 		Optional<Member> byNickName = memberRepository.findByNickName(request.getNickName());
 		if (byNickName.isEmpty()) {
@@ -51,5 +51,10 @@ public class MemberServiceImpl implements MemberService {
 		} else {
 			throw new MemberDuplicateNickName(byNickName.get().getNickName());
 		}
+	}
+
+	@Override
+	public MemberReportResponse getMyReport(Long memberId) {
+		return memberRepository.findReportById(memberId);
 	}
 }

--- a/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/api/MemberControllerTest.java
@@ -111,4 +111,25 @@ class MemberControllerTest extends RestDocsSupport {
 				)
 			));
 	}
+
+	@Test
+	@DisplayName("사용자는 자신의 요악된 정보를 조회 할 수 있다.")
+	void getMyReportTest() throws Exception {
+
+		//when then
+		mockMvc.perform(get("/users/me/report")
+				.header("Authorization", "Bearer " + accessToken))
+			.andExpect(status().isOk())
+			.andDo(restDocs.document(
+				requestHeaders(
+					headerWithName("Authorization").description("JWT Access 토큰")
+				),
+				responseFields(
+					beneathPath("data").withSubsectionId("data"),
+					fieldWithPath("numOfPost").description("회원이 작성한 글"),
+					fieldWithPath("numOfComment").description("회원이 작성한 댓글"),
+					fieldWithPath("numOfBookmark").description("회원이 등록한 북마크")
+				)
+			));
+	}
 }

--- a/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/member/repository/MemberRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import com.clover.habbittracker.domain.member.dto.MemberReportResponse;
 import com.clover.habbittracker.domain.member.entity.Member;
 import com.clover.habbittracker.global.config.db.JpaConfig;
 
@@ -20,17 +21,13 @@ import com.clover.habbittracker.global.config.db.JpaConfig;
 @Import(JpaConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemberRepositoryTest {
-
-	private final MemberRepository memberRepository;
-
 	@Autowired
-	public MemberRepositoryTest(MemberRepository memberRepository) {
-		this.memberRepository = memberRepository;
-	}
+	private MemberRepository memberRepository;
+	private Member savedMember;
 
 	@BeforeEach
 	void setMemberData() {
-		memberRepository.save(createTestMember());
+		savedMember = memberRepository.save(createTestMember());
 	}
 
 	@Test
@@ -75,5 +72,18 @@ class MemberRepositoryTest {
 		Optional<Member> deleteMember = memberRepository.findById(getId());
 		//then
 		assertThat(deleteMember).isEmpty();
+	}
+
+	@Test
+	@DisplayName("사용자는 ID 로 자신의 저장된 데이터를 조회 할 수 있다.")
+	void findMemberReport() {
+
+		//when
+		MemberReportResponse response = memberRepository.findReportById(savedMember.getId());
+		//then
+		assertThat(response.numOfPost()).isEqualTo(savedMember.getPosts().size());
+		assertThat(response.numOfComment()).isEqualTo(savedMember.getComments().size());
+		assertThat(response.numOfBookmark()).isEqualTo(savedMember.getBookmarks().size());
+
 	}
 }


### PR DESCRIPTION
# 작업사항
- #49 

사용자가 이용내역을 조회 하기 위한 API 를 추가하였습니다.

## 작업내용
기존 게시글 요약정보 조회와 같이 JPA 에서 DTO 를 직접 받아서 쓰도록 하였습니다.
이유는 count 쿼리로 간단하게 개수만 받아오기 위해 그렇게 설정했습니다!

[feat : Member 관계 추가](https://github.com/Clover-Habiters/backend/commit/48697974744e4278936b71c2043c3fb6d70d50af) 
- Member 로 게시글,댓글,북마크의 관계를 양방향으로 추가하였습니다.
- Member 를 기준으로 사용 내역을 조회 하기 위하여 추가하였습니다.

[feat : 사용자 이용 내역 조회 추가](https://github.com/Clover-Habiters/backend/commit/399f8c1912da865302a925d1e6887e6788dd0b0d) 
- 사용자가 커뮤니티 활동을 하며 이용한 내역을 조회 할 수 있는 API 를 추가하였습니다.
- 보고서 형태라고 생각하여 URL 은 report 라고 추가하였습니다.
- MemberReportResponse DTO 클래스로 바로 반환받아 응답하도록 구현하였습니다.

[feat : 사용자 이용내역 쿼리 추가](https://github.com/Clover-Habiters/backend/commit/2ac330d8ec1dcff47f9e7ace93859977f70773d6) 
- 이전 게시글 요약정보와 마찬가지로 이용내역의 총 count 정보만 필요하기에 DTO 클래스로 바로 반환 받도록 하였습니다.
- 쿼리문은 각 필요한 내용을 count 하여 총 갯수만 가져오도록 설정하였습니다.

[feat(Test) : 사용자 이용 내역 테스트 코드 추가](https://github.com/Clover-Habiters/backend/commit/7b95a9e142286d94e1e38550a11b5f582e05e18a) 
- 정상적으로 쿼리가 실행되어 count 정보가 정확하게 오는지 테스트 하였습니다.
- API 문서화 내용을 추가하였습니다.