### PR TITLE
[#51] 게시글 검색 및 조회 이슈사항 수정

### DIFF
--- a/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/api/PostController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -72,7 +73,7 @@ public class PostController {
 	@GetMapping("/search")
 	public ResponseEntity<ApiResponse<Page<PostResponse>>> searchPost(
 		@PageableDefault(size = 15) Pageable pageable,
-		@Valid @RequestBody PostSearchCondition postSearchCondition
+		@Valid @ModelAttribute PostSearchCondition postSearchCondition
 	) {
 		Page<PostResponse> postPages = postService.getPostBy(postSearchCondition, pageable);
 		ApiResponse<Page<PostResponse>> response = ApiResponse.success(postPages);

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostResponse.java
@@ -10,6 +10,7 @@ import com.querydsl.core.annotations.QueryProjection;
 
 public record PostResponse(
 	Long id,
+	Long authorId,
 	String title,
 	String content,
 	String thumbnailUrl,

--- a/src/main/java/com/clover/habbittracker/domain/post/dto/PostSearchCondition.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/dto/PostSearchCondition.java
@@ -10,10 +10,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 public class PostSearchCondition {
 

--- a/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/clover/habbittracker/domain/post/repository/PostCustomRepositoryImpl.java
@@ -110,6 +110,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 	private QPostResponse QPostResponse() {
 		return new QPostResponse(
 			post.id,
+			post.member.id,
 			post.title,
 			post.content,
 			post.thumbnailUrl,

--- a/src/test/java/com/clover/habbittracker/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/clover/habbittracker/domain/post/api/PostControllerTest.java
@@ -102,6 +102,7 @@ class PostControllerTest extends RestDocsSupport {
 				responseFields(
 					beneathPath("data").withSubsectionId("data"),
 					fieldWithPath("id").type(NUMBER).description("게시글 id"),
+					fieldWithPath("authorId").type(NUMBER).description("작성자 id"),
 					fieldWithPath("title").type(STRING).description("게시글 제목"),
 					fieldWithPath("content").type(STRING).description("게시글 본문"),
 					fieldWithPath("thumbnailUrl").description("게시글 썸네일 url"),
@@ -159,7 +160,6 @@ class PostControllerTest extends RestDocsSupport {
 		PostSearchCondition postSearchCondition =
 			new PostSearchCondition(Post.Category.DAILY, PostSearchCondition.SearchType.TITLE, searchPost.getTitle());
 		String request = objectMapper.writeValueAsString(postSearchCondition);
-
 		//when then
 		mockMvc.perform(get("/posts/search")
 				.header("Authorization", "Bearer " + accessToken)


### PR DESCRIPTION
# 작업사항
- #51 


## 작업 내용
[chore : 게시글 검색 수정](https://github.com/Clover-Habiters/backend/commit/953bda8769a381e779ab001c34a02a10c8b84e8c)  
- 게시글을 검색 할 경우 axios 에서는 get 요청으로 body 에 데이터를 심을 수 없는 상황으로 @ModelAttribute 로 파라미터로 받을 수 있도록 수정하였습니다.
- 기본 생성자를 제거하여 Setter 메서드를 사용하지 않도록 하였습니다.
(기본 생성자가 있을 경우 무조건 기본생성자로 사용 후 데이터 매핑을 진행하기에 Setter 가 필수로 들어가게됨)

[chore : 게시글 리스트 조회시 작성자 id 표시](https://github.com/Clover-Habiters/backend/commit/6c5f951fb7a3faecf69774615ad0c95dea1651f1) 
- 게시글 리스트를 조회 할 경우 작성자의 아이디를 같이 표기하도록 수정하였습니다.
- restdocs 문서화에 해당 내용도 업데이트하였습니다.